### PR TITLE
INSPECTIT-1918: Adapt the release artifact names to a common pattern

### DIFF
--- a/Agent/build.properties
+++ b/Agent/build.properties
@@ -1,5 +1,5 @@
 dist.jar.name=inspectit-agent.jar
-release.name.sun15=inspectit-agent-sun1.5.zip
+release.name.sun15=inspectit-agent-sun1.5-${env.VERSION}.zip
 module.version.target=0.1
 
 ## Ivy

--- a/Agent/build.xml
+++ b/Agent/build.xml
@@ -15,6 +15,7 @@
 	<!--                      S E T T I N G S                            -->
 	<!-- *************************************************************** -->
 
+	<property environment="env" />
 	<property file="${basedir}/build.properties" />
 
 	<import file="${build.common-targets.file}" />

--- a/CMR/build.xml
+++ b/CMR/build.xml
@@ -291,7 +291,7 @@
 	<target name="-linux-x86">
 		<copy file="${basedir}/startup.sh" tofile="${build.scripts}/startup.sh"/>
 		<replaceregexp file="${build.scripts}/startup.sh" match="#COMMAND#" replace="${cmr.java.command.linux} ${cmr.java.memory.32bit} ${cmr.java.opts.32bit} ${cmr.java.opts.linux} ${cmr.java.locgc.linux} -jar ${dist.jar.name}" byline="true"/>
-		<tar destfile="${release.root}/inspectit-cmr.linux.x86.tar.gz" compression="gzip">
+		<tar destfile="${release.root}/inspectit-cmr.linux.x86-${env.VERSION}.tar.gz" compression="gzip">
 			<fileset dir="${build.release.root}" />
 			<tarfileset file="${build.scripts}/startup.sh" prefix="CMR" filemode="755" />
 			<zipfileset src="${jvm.root}/jre7-linux-x86.zip" prefix="CMR/jre" filemode="755" />
@@ -303,7 +303,7 @@
 	<target name="-linux-x64">
 		<copy file="${basedir}/startup.sh" tofile="${build.scripts}/startup.sh"/>
 		<replaceregexp file="${build.scripts}/startup.sh" match="#COMMAND#" replace="${cmr.java.command.linux} ${cmr.java.memory.64bit} ${cmr.java.opts.64bit} ${cmr.java.opts.linux} ${cmr.java.locgc.linux} -jar ${dist.jar.name}" byline="true"/>
-		<tar destfile="${release.root}/inspectit-cmr.linux.x64.tar.gz" compression="gzip">
+		<tar destfile="${release.root}/inspectit-cmr.linux.x64-${env.VERSION}.tar.gz" compression="gzip">
 			<fileset dir="${build.release.root}" />
 			<tarfileset file="${build.scripts}/startup.sh" prefix="CMR" filemode="755" />
 			<zipfileset src="${jvm.root}/jre7-linux-x64.zip" prefix="CMR/jre" filemode="755" />
@@ -315,7 +315,7 @@
 	<target name="-windows-x86">
 		<copy file="${basedir}/startup.bat" tofile="${build.scripts}/startup.bat"/>
 		<replaceregexp file="${build.scripts}/startup.bat" match="#COMMAND#" replace="${cmr.java.command.win} ${cmr.java.memory.32bit} ${cmr.java.opts.32bit} ${cmr.java.opts.win} ${cmr.java.locgc.win} -jar ${dist.jar.name}" byline="true"/>
-		<zip destfile="${release.root}/inspectit-cmr.windows.x86.zip">
+		<zip destfile="${release.root}/inspectit-cmr.windows.x86-${env.VERSION}.zip">
 			<fileset dir="${build.release.root}" />
 			<zipfileset file="${build.scripts}/startup.bat" prefix="CMR" />
 			<zipfileset src="${jvm.root}/jre7-windows-x86.zip" prefix="CMR/jre" />
@@ -327,7 +327,7 @@
 	<target name="-windows-x64">
 		<copy file="${basedir}/startup.bat" tofile="${build.scripts}/startup.bat"/>
 		<replaceregexp file="${build.scripts}/startup.bat" match="#COMMAND#" replace="${cmr.java.command.win} ${cmr.java.memory.64bit} ${cmr.java.opts.64bit} ${cmr.java.opts.win} ${cmr.java.locgc.win} -jar ${dist.jar.name}" byline="true"/>
-		<zip destfile="${release.root}/inspectit-cmr.windows.x64.zip">
+		<zip destfile="${release.root}/inspectit-cmr.windows.x64-${env.VERSION}.zip">
 			<fileset dir="${build.release.root}" />
 			<zipfileset file="${build.scripts}/startup.bat" prefix="CMR" />
 			<zipfileset src="${jvm.root}/jre7-windows-x64.zip" prefix="CMR/jre" />

--- a/Commons/resources/shared/build/common-targets.properties
+++ b/Commons/resources/shared/build/common-targets.properties
@@ -50,36 +50,36 @@ cpd.report.file=${cpd.config.root}/cpdhtml.xslt
 ## installer
 commons.dir = ${basedir}
 commons.installer.resources = ${commons.dir}/resources/installer/installer-commons
-installer.windows64.name = inspectit.installer-all.win.x64.jar
-installer.windows32.name = inspectit.installer-all.win.x86.jar
-installer.linux64.name = inspectit.installer-all.linux.x64.jar
-installer.linux32.name = inspectit.installer-all.linux.x86.jar
+installer.windows64.name = inspectit-installer-all.windows.x64-${env.VERSION}.jar
+installer.windows32.name = inspectit-installer-all.windows.x86-${env.VERSION}.jar
+installer.linux64.name = inspectit-installer-all.linux.x64-${env.VERSION}.jar
+installer.linux32.name = inspectit-installer-all.linux.x86-${env.VERSION}.jar
 
 output.dir = ${commons.dir}/build/installers/
 
 ## agent
 agent.release.dir = ${basedir}/../Agent/release
-agent.build = ${agent.release.dir}/inspectit-agent-sun1.5.zip
+agent.build = ${agent.release.dir}/inspectit-agent-sun1.5-${env.VERSION}.zip
 agent.installer.working.dir = ${agent.release.dir}/installer
 agent.installer.name = inspectit-agent-sun1.5-installer
 
 ## cmr
 cmr.release.dir = ${basedir}/../CMR/release
 
-cmr.build.linux64 = ${cmr.release.dir}/inspectit-cmr.linux.x64.tar.gz
-cmr.build.linux86 = ${cmr.release.dir}/inspectit-cmr.linux.x86.tar.gz
-cmr.build.win64 = ${cmr.release.dir}/inspectit-cmr.windows.x64.zip
-cmr.build.win86 = ${cmr.release.dir}/inspectit-cmr.windows.x86.zip
+cmr.build.linux64 = ${cmr.release.dir}/inspectit-cmr.linux.x64-${env.VERSION}.tar.gz
+cmr.build.linux86 = ${cmr.release.dir}/inspectit-cmr.linux.x86-${env.VERSION}.tar.gz
+cmr.build.win64 = ${cmr.release.dir}/inspectit-cmr.windows.x64-${env.VERSION}.zip
+cmr.build.win86 = ${cmr.release.dir}/inspectit-cmr.windows.x86-${env.VERSION}.zip
 
 cmr.installer.working.dir = ${cmr.release.dir}/installer
 
 ## inspecit
 inspectit.release.dir = ${basedir}/../inspectIT/release/dist
 
-inspectit.build.linux64 = ${inspectit.release.dir}/inspectit-linux.gtk.x86_64.zip
-inspectit.build.linux86 = ${inspectit.release.dir}/inspectit-linux.gtk.x86.zip
-inspectit.build.win64 = ${inspectit.release.dir}/inspectit-win32.win32.x86_64.zip
-inspectit.build.win86 = ${inspectit.release.dir}/inspectit-win32.win32.x86.zip
+inspectit.build.linux64 = ${inspectit.release.dir}/inspectit-ui.linux.gtk.x64-${env.VERSION}.zip
+inspectit.build.linux86 = ${inspectit.release.dir}/inspectit-ui.linux.gtk.x86-${env.VERSION}.zip
+inspectit.build.win64 = ${inspectit.release.dir}/inspectit-ui.windows.x64-${env.VERSION}.zip
+inspectit.build.win86 = ${inspectit.release.dir}/inspectit-ui.windows.x86-${env.VERSION}.zip
 
 inspectit.installer.working.dir = ${inspectit.release.dir}/installer
 

--- a/Commons/resources/shared/build/common-targets.xml
+++ b/Commons/resources/shared/build/common-targets.xml
@@ -8,6 +8,8 @@
 		This build file has the common targets used by all other inspectIT components
 	</description>
 
+	<property environment="env" />
+
 	<dirname property="commontargets.basedir" file="${ant.file.CommonTargets}" />
 	<property file="${commontargets.basedir}/common-targets.properties" />
 	<property file="${commontargets.basedir}/cmr-startup.properties" />

--- a/inspectIT/release/build.xml
+++ b/inspectIT/release/build.xml
@@ -1,5 +1,7 @@
 <project name="inspectIT RCP" default="release" xmlns:ivy="antlib:org.apache.ivy.ant">
 
+	<property environment="env" />
+
 	<property name="release.basedir" value="${basedir}" />
 	<property file="build.properties" />
 
@@ -290,32 +292,32 @@
 		<!-- copy the jvms -->
 		<antcall target="-retrieve-jre-installations" />
 
-		<zip destfile="${release.basedir}/dist/inspectit-win32.win32.x86.zip" update="true">
+		<zip destfile="${release.basedir}/dist/inspectit-ui.windows.x86-${env.VERSION}.zip" update="true">
 			<zipfileset dir="${basedir}/../../" prefix="inspectit" includes="*LICENSE*.txt" />
 			<zipfileset src="${jvm.root}/jre7-windows-x86.zip" prefix="inspectit/jre" filemode="775" />
 			<zipfileset dir=".." prefix="inspectit" includes="logging-config.xml" />
 		</zip>
-		<zip destfile="${release.basedir}/dist/inspectit-win32.win32.x86_64.zip" update="true">
+		<zip destfile="${release.basedir}/dist/inspectit-ui.windows.x64-${env.VERSION}.zip" update="true">
 			<zipfileset dir="${basedir}/../../" prefix="inspectit" includes="*LICENSE*.txt" />
 			<zipfileset src="${jvm.root}/jre7-windows-x64.zip" prefix="inspectit/jre" filemode="775" />
 			<zipfileset dir=".." prefix="inspectit" includes="logging-config.xml" />
 		</zip>
-		<zip destfile="${release.basedir}/dist/inspectit-linux.gtk.x86.zip" update="true">
+		<zip destfile="${release.basedir}/dist/inspectit-ui.linux.gtk.x86-${env.VERSION}.zip" update="true">
 			<zipfileset dir="${basedir}/../../" prefix="inspectit" includes="*LICENSE*.txt" />
 			<zipfileset src="${jvm.root}/jre7-linux-x86.zip" prefix="inspectit/jre" filemode="775" />
 			<zipfileset dir=".." prefix="inspectit" includes="logging-config.xml" />
 		</zip>
-		<zip destfile="${release.basedir}/dist/inspectit-linux.gtk.x86_64.zip" update="true">
+		<zip destfile="${release.basedir}/dist/inspectit-ui.linux.gtk.x64-${env.VERSION}.zip" update="true">
 			<zipfileset dir="${basedir}/../../" prefix="inspectit" includes="*LICENSE*.txt" />
 			<zipfileset src="${jvm.root}/jre7-linux-x64.zip" prefix="inspectit/jre" filemode="775" />
 			<zipfileset dir=".." prefix="inspectit" includes="logging-config.xml" />
 		</zip>
 		<!-- No JRE packing for the Mac x32 version -->
-		<zip destfile="${release.basedir}/dist/inspectit-macosx.cocoa.x86.zip" update="true">
+		<zip destfile="${release.basedir}/dist/inspectit-ui.macosx.cocoa.x86-${env.VERSION}.zip" update="true">
 			<zipfileset dir="${basedir}/../../" prefix="inspectit" includes="*LICENSE*.txt" />
 			<zipfileset dir=".." prefix="inspectit" includes="logging-config.xml" />
 		</zip>
-		<zip destfile="${release.basedir}/dist/inspectit-macosx.cocoa.x86_64.zip" update="true">
+		<zip destfile="${release.basedir}/dist/inspectit-ui.macosx.cocoa.x64-${env.VERSION}.zip" update="true">
 			<zipfileset dir="${basedir}/../../" prefix="inspectit" includes="*LICENSE*.txt" />
 			<zipfileset src="${jvm.root}/jre7-macosx-x64.zip" prefix="inspectit/jre" filemode="775" />
 			<zipfileset dir=".." prefix="inspectit" includes="logging-config.xml" />


### PR DESCRIPTION
Created script generating the release information xml file as described in
https://inspectit-performance.atlassian.net/wiki/display/DEV/Homepage+Release+description
(Ticket INSPECTIT-1918).
Furthermore, changed the release artifact names to match the pattern.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/22)
<!-- Reviewable:end -->
