### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/Commons/resources/ivy/ivy.xml
+++ b/Commons/resources/ivy/ivy.xml
@@ -26,7 +26,7 @@
 		<dependency org="org.slf4j" name="slf4j-api" rev="1.7.5" conf="prod->default" />
 
 		<dependency org="commons-lang" name="commons-lang" rev="2.5" conf="prod->default" />
-		<dependency org="commons-collections" name="commons-collections" rev="3.2.1" conf="prod->default" />
+		<dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="prod->default" />
 		<dependency org="commons-pool" name="commons-pool" rev="1.6" conf="prod->default" />
 
 		<dependency org="org.springframework" name="info.novatec.spring-core" rev="3.2.16" conf="prod->default" />

--- a/CommonsCS/resources/ivy/ivy.xml
+++ b/CommonsCS/resources/ivy/ivy.xml
@@ -23,7 +23,7 @@
 
 	<dependencies>
 		<dependency org="commons-pool" name="commons-pool" rev="1.6" conf="prod->default" />
-		<dependency org="commons-collections" name="commons-collections" rev="3.2.1" conf="prod->default" />
+		<dependency org="commons-collections" name="commons-collections" rev="3.2.2" conf="prod->default" />
 		
 		<!-- Using Hamcrest matchers in Validators -->
 		<dependency org="org.hamcrest" name="info.novatec.hamcrest-all" rev="1.3" conf="prod->default" />


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/72)
<!-- Reviewable:end -->
