### PR TITLE
INSPECTIT-2105: squid:S1192 - String literals should not be duplicated

### DIFF
--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/analyzer/impl/ByteCodeAnalyzer.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/analyzer/impl/ByteCodeAnalyzer.java
@@ -56,6 +56,11 @@ import rocks.inspectit.shared.all.spring.logger.Log;
 public class ByteCodeAnalyzer implements IByteCodeAnalyzer, InitializingBean {
 
 	/**
+	 * Error message for problems during instrumentation.
+	 */
+	private static final String ERROR_OCCURRED_INSTRUMENTING_THE_BYTE_CODE_OF_CLASS = "Error occurred instrumenting the byte code of class ";
+
+	/**
 	 * Log for the class.
 	 */
 	@Log
@@ -192,16 +197,16 @@ public class ByteCodeAnalyzer implements IByteCodeAnalyzer, InitializingBean {
 				return null;
 			}
 		} catch (IdNotAvailableException idNotAvailableException) {
-			log.error("Error occurred instrumenting the byte code of class " + className, idNotAvailableException);
+			log.error(ERROR_OCCURRED_INSTRUMENTING_THE_BYTE_CODE_OF_CLASS + className, idNotAvailableException);
 			return null;
 		} catch (ServerUnavailableException serverUnavailableException) {
-			log.error("Error occurred instrumenting the byte code of class " + className, serverUnavailableException);
+			log.error(ERROR_OCCURRED_INSTRUMENTING_THE_BYTE_CODE_OF_CLASS + className, serverUnavailableException);
 			return null;
 		} catch (BusinessException businessException) {
-			log.error("Error occurred instrumenting the byte code of class " + className, businessException);
+			log.error(ERROR_OCCURRED_INSTRUMENTING_THE_BYTE_CODE_OF_CLASS + className, businessException);
 			return null;
 		} catch (StorageException storageException) {
-			log.error("Error occurred instrumenting the byte code of class " + className, storageException);
+			log.error(ERROR_OCCURRED_INSTRUMENTING_THE_BYTE_CODE_OF_CLASS + className, storageException);
 			return null;
 		}
 	}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/connection/impl/KryoNetConnection.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/connection/impl/KryoNetConnection.java
@@ -44,6 +44,25 @@ import rocks.inspectit.shared.all.spring.logger.Log;
  */
 @Component
 public class KryoNetConnection implements IConnection {
+	/**
+	 * Register platform message.
+	 */
+	private static final String REGISTER_PLATFORM_LIST_STRING = "registerPlatform(List,String)";
+
+	/**
+	 * * Unregister platform message.
+	 */
+	private static final String UNREGISTER_PLATFORM_LONG = "unregisterPlatform(long)";
+
+	/**
+	 * Platform not registered message.
+	 */
+	private static final String COULD_NOT_REGISTER_THE_PLATFORM = "Could not register the platform";
+
+	/**
+	 * Platform not unregistered message.
+	 */
+	private static final String COULD_NOT_UN_REGISTER_THE_PLATFORM = "Could not un-register the platform";
 
 	/**
 	 * The logger of the class.
@@ -206,9 +225,9 @@ public class KryoNetConnection implements IConnection {
 		} catch (SocketException socketException) {
 			log.error("Could not obtain network interfaces from this machine!");
 			if (log.isTraceEnabled()) {
-				log.trace("unregister(List,String)", socketException);
+				log.trace(REGISTER_PLATFORM_LIST_STRING, socketException);
 			}
-			throw new RegistrationException("Could not un-register the platform", socketException);
+			throw new RegistrationException(COULD_NOT_REGISTER_THE_PLATFORM, socketException);
 		}
 
 		// make call
@@ -223,14 +242,14 @@ public class KryoNetConnection implements IConnection {
 			return call.makeCall();
 		} catch (ExecutionException executionException) {
 			if (log.isTraceEnabled()) {
-				log.trace("register(String, String)", executionException);
+				log.trace(REGISTER_PLATFORM_LIST_STRING, executionException);
 			}
 			// check for business exception
 			if (executionException.getCause() instanceof BusinessException) {
 				throw ((BusinessException) executionException.getCause()); // NOPMD
 			}
 
-			throw new RegistrationException("Could not register the platform", executionException.getCause()); // NOPMD
+			throw new RegistrationException(COULD_NOT_REGISTER_THE_PLATFORM, executionException.getCause()); // NOPMD
 		}
 	}
 
@@ -255,14 +274,14 @@ public class KryoNetConnection implements IConnection {
 			call.makeCall();
 		} catch (ExecutionException executionException) {
 			if (log.isTraceEnabled()) {
-				log.trace("unregister(long)", executionException);
+				log.trace(UNREGISTER_PLATFORM_LONG, executionException);
 			}
 			// check for business exception
 			if (executionException.getCause() instanceof BusinessException) {
 				throw ((BusinessException) executionException.getCause()); // NOPMD
 			}
 
-			throw new RegistrationException("Could not un-register the platform", executionException.getCause()); // NOPMD
+			throw new RegistrationException(COULD_NOT_UN_REGISTER_THE_PLATFORM, executionException.getCause()); // NOPMD
 		}
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 140 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/94)

<!-- Reviewable:end -->
