### PR TITLE
INSPECTIT-2090 - amend to be able to compile it with JDK 8

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -240,7 +240,10 @@ dependencies {
 		'org.openjdk.jmh:jmh-generator-annprocess:1.11.3'
 	)
 	xjc (
-		'com.sun.xml.bind:jaxb-xjc:2.2.4-1'
+		'com.sun.xml.bind:jaxb-jxc:2.2.11',
+		'com.sun.xml.bind:jaxb-xjc:2.2.11',
+		'com.sun.xml.bind:jaxb-impl:2.2.11',
+		'com.sun.xml.bind:jaxb-core:2.2.11'
 	)
 	izpack (
 		'org.codehaus.izpack:izpack-standalone-compiler:4.3.5',

--- a/inspectit.server/inspectit.server.gradle
+++ b/inspectit.server/inspectit.server.gradle
@@ -117,6 +117,7 @@ def schemagen(sourceDir, outputDir, fileName, excludes) {
 				destdir: outputDir,
 				excludes: excludes,
 				includeAntRuntime: 'false',
+				classpath: sourceSets.main.runtimeClasspath.asPath,
 				debug: 'true'
 			)
 


### PR DESCRIPTION
Related to the comment on [INSPECTIT-1958](https://inspectit-performance.atlassian.net/browse/INSPECTIT-1958) why the compilation is pinned to JDK 7 I have not submitted a new JIRA ticket.

With this pull request users interested to compile with JDK 8 at least have the possibility to do it. Also they are informed about the impact (explained on the linked JIRA ticket).

**note** Check the comments in [#115](https://github.com/inspectIT/inspectIT/issues/115) to see why it's not suggested to compile with JDK 8.

closes #115

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/116)
<!-- Reviewable:end -->
