### PR TITLE
INSPECTIT-2472: Allow JVM system properties to be referenced in the agent name

### DIFF
--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/config/impl/ConfigurationStorage.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/config/impl/ConfigurationStorage.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -388,19 +390,42 @@ public class ConfigurationStorage implements IConfigurationStorage, Initializing
 		// agent name
 		String agentName = System.getProperty(AGENT_NAME_PROPERTY);
 		if (StringUtils.isNotBlank(agentName)) {
+			String newAgentName = checkPatternAgentName(agentName);
 			try {
-				log.info("Agent name found in the JVM parameters: AgentName=" + agentName);
-				setAgentName(agentName);
+				log.info("Agent name found in the JVM parameters: AgentName=" + newAgentName);
+				setAgentName(newAgentName);
 			} catch (Exception e) {
 				log.warn("Agent name could not be defined from the data in the JVM parameters", e);
 			}
 		} else {
 			try {
+				log.info("Agent name set by default: AgentName = " + DEFAULT_AGENT_NAME);
 				setAgentName(DEFAULT_AGENT_NAME);
 			} catch (StorageException e) {
 				log.warn("Agent name could not be defined from default agent name", e);
 			}
 		}
+	}
+
+	/**
+	 * @param originalAgentName
+	 *            Name of the agent passed by the user in the JVM arguments.
+	 *
+	 * @return Returns the name of the agent based in the pattern in case the argument has one,
+	 *         otherwise the name of the agent will be the DEFAULT_NAME concatenated with the PID.
+	 */
+	private String checkPatternAgentName(String originalAgentName) {
+		Pattern pattern = Pattern.compile("\\$\\{(.+?)\\}");
+		Matcher matcher = pattern.matcher(originalAgentName);
+		if (matcher.find()) {
+			String propertyName = matcher.group(1);
+			if (System.getProperty(propertyName) != null) {
+				return matcher.replaceFirst(System.getProperty(propertyName));
+			} else {
+				return matcher.replaceFirst("NA");
+			}
+		}
+		return originalAgentName;
 	}
 
 	/**

--- a/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/config/impl/ConfigurationStorageTest.java
+++ b/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/config/impl/ConfigurationStorageTest.java
@@ -106,6 +106,99 @@ public class ConfigurationStorageTest extends TestBase {
 			assertThat(configurationStorage.getRepositoryConfig().getPort(), is(8000));
 			assertThat(configurationStorage.getAgentName(), is(not(nullValue())));
 		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsAtTheEndOfTheNameAndItIsNotRecognize() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "agentName_${test}");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("agentName_NA")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsAtTheEndOfTheNameAndItIsFromSystemProperties() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "agentName_${systemProperty}");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+			properties.put("systemProperty", "systemPropertyValue");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("agentName_systemPropertyValue")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsInTheMiddleOfTheNameAndItIsNotRecognize() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "agent_${test}_Name");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("agent_NA_Name")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsInTheMiddleOfTheNameAndItIsFromSystemProperties() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "agent_${systemProperty}_Name");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+			properties.put("systemProperty", "systemPropertyValue");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("agent_systemPropertyValue_Name")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsAtTheBegginingOfTheNameAndItIsNotRecognize() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "${test}_agentName");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("NA_agentName")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsAtTheBegginingOfTheNameAndItIsFromSystemProperties() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "${systemProperty}_agentName");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+			properties.put("systemProperty", "systemPropertyValue");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("systemPropertyValue_agentName")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsAtTheBegginingOfTheNameAndThereIsMoreThanOnePatternInTheArgumentWhenThePropertyIsTheFirstFound() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "${systemProperty}_agent_${systemProperty}_Name_${test}");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+			properties.put("systemProperty", "systemPropertyValue");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("systemPropertyValue_agent_${systemProperty}_Name_${test}")));
+		}
+
+		@Test
+		public void agentNameIsCorrectIfThePatternIsAtTheBegginingOfTheNameAndThereIsMoreThanOnePatternInTheArgumentWhenThePropertyIsNotTheFirstFound() throws Exception {
+			Properties properties = System.getProperties();
+			properties.put(ConfigurationStorage.AGENT_NAME_PROPERTY, "${test}_agentName_${systemProperty}");
+			properties.put(ConfigurationStorage.REPOSITORY_PROPERTY, "localhost:8000");
+			properties.put("systemProperty", "systemPropertyValue");
+
+			configurationStorage.afterPropertiesSet();
+
+			assertThat(configurationStorage.getAgentName(), is(("NA_agentName_${systemProperty}")));
+		}
 	}
 
 	public class GetAgentName extends ConfigurationStorageTest {


### PR DESCRIPTION
Check if pattern exists in the agentName, if exists, retrieve the information to set the name from the environment or properties, otherwise return the agent name. Tests added

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/317)
<!-- Reviewable:end -->
