### PR TITLE
INSPECTIT-2458: Support remote tracing with Apache HttpAsyncClient

### DIFF
--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/async/http/ApacheClientExchangeHandlerHook.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/async/http/ApacheClientExchangeHandlerHook.java
@@ -1,0 +1,60 @@
+package rocks.inspectit.agent.java.sensor.method.async.http;
+
+import rocks.inspectit.agent.java.config.impl.RegisteredSensorConfig;
+import rocks.inspectit.agent.java.core.ICoreService;
+import rocks.inspectit.agent.java.hooking.IMethodHook;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.store.ApacheHttpContextSpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.agent.java.util.ReflectionCache;
+
+/**
+ * Sensor hook for hooking into the generation of asynchronous HTTP requests in order to be able to
+ * start spans for tracing purpose.
+ * <p>
+ * Thereto, the method <code>generateRequest</code> of the Apache's
+ * <code>org.apache.http.impl.nio.client.AbstractClientExchangeHandler</code> class will be
+ * instrumented.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+public class ApacheClientExchangeHandlerHook implements IMethodHook {
+
+	/**
+	 * Cache for caching the reflection calls.
+	 */
+	private static final ReflectionCache REFLECTION_CACHE = new ReflectionCache();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void beforeBody(long methodId, long sensorTypeId, Object object, Object[] parameters, RegisteredSensorConfig rsc) {
+		Object httpContext = REFLECTION_CACHE.getField(object.getClass(), "localContext", object, null);
+
+		if (httpContext != null) {
+			SpanStoreAdapter spanStoreAdapter = new ApacheHttpContextSpanStoreAdapter(httpContext);
+			SpanStore spanStore = spanStoreAdapter.getSpanStore();
+
+			if (spanStore != null) {
+				spanStore.startSpan();
+			}
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void firstAfterBody(long methodId, long sensorTypeId, Object object, Object[] parameters, Object result, boolean exception, RegisteredSensorConfig rsc) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void secondAfterBody(ICoreService coreService, long methodId, long sensorTypeId, Object object, Object[] parameters, Object result, boolean exception, RegisteredSensorConfig rsc) {// NOCHK:8-params
+	}
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/async/http/ApacheClientExchangeHandlerSensor.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/async/http/ApacheClientExchangeHandlerSensor.java
@@ -1,0 +1,41 @@
+package rocks.inspectit.agent.java.sensor.method.async.http;
+
+import java.util.Map;
+
+import rocks.inspectit.agent.java.hooking.IHook;
+import rocks.inspectit.agent.java.hooking.IMethodHook;
+import rocks.inspectit.agent.java.sensor.method.AbstractMethodSensor;
+import rocks.inspectit.agent.java.sensor.method.IMethodSensor;
+
+/**
+ * Sensor for the <code>org.apache.http.impl.nio.client.AbstractClientExchangeHandler</code> of the
+ * Apache asynchronous HTTP client.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+public class ApacheClientExchangeHandlerSensor extends AbstractMethodSensor implements IMethodSensor {
+
+	/**
+	 * Hook to use.
+	 */
+	private IMethodHook hook;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public IHook getHook() {
+		return hook;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected void initHook(Map<String, Object> parameters) {
+		hook = new ApacheClientExchangeHandlerHook();
+	}
+
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/remote/client/http/ApacheAsyncHttpClientSensor.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/remote/client/http/ApacheAsyncHttpClientSensor.java
@@ -1,0 +1,55 @@
+package rocks.inspectit.agent.java.sensor.method.remote.client.http;
+
+import io.opentracing.propagation.TextMap;
+import rocks.inspectit.agent.java.config.impl.RegisteredSensorConfig;
+import rocks.inspectit.agent.java.sensor.method.remote.client.RemoteAsyncClientSensor;
+import rocks.inspectit.agent.java.tracing.core.adapter.AsyncClientAdapterProvider;
+import rocks.inspectit.agent.java.tracing.core.adapter.AsyncClientRequestAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.AsyncHttpClientRequestAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.data.impl.ApacheHttpClientV40HttpClientRequest;
+import rocks.inspectit.agent.java.tracing.core.adapter.store.ApacheHttpContextSpanStoreAdapter;
+import rocks.inspectit.agent.java.util.ReflectionCache;
+
+/**
+ *
+ * Remote client sensor for intercepting asynchronous HTTP calls made with Apache HTTP client.
+ * <p>
+ * Targeted instrumentation method:
+ * <ul>
+ * <li>{@code org.apache.http.nio.client.HttpAsyncClient#execute(org.apache.http.HttpHost org.apache.http.HttpRequest org.apache.http.protocol.HttpContext org.apache.http.concurrent.FutureCallback)}
+ * </ul>
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+public class ApacheAsyncHttpClientSensor extends RemoteAsyncClientSensor implements AsyncClientAdapterProvider {
+
+	/**
+	 * The reflection cache to use in this class.
+	 */
+	private static final ReflectionCache CACHE = new ReflectionCache();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public AsyncClientRequestAdapter<TextMap> getAsyncClientRequestAdapter(Object object, Object[] parameters, RegisteredSensorConfig rsc) {
+		Object httpContext = parameters[2];
+		SpanStoreAdapter spanStoreAdapter = new ApacheHttpContextSpanStoreAdapter(httpContext);
+
+		Object httpRequest = parameters[1];
+		ApacheHttpClientV40HttpClientRequest clientRequest = new ApacheHttpClientV40HttpClientRequest(httpRequest, CACHE);
+
+		return new AsyncHttpClientRequestAdapter(clientRequest, spanStoreAdapter);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected AsyncClientAdapterProvider getAsyncClientAdapterProvider() {
+		return this;
+	}
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/special/CloseableHttpAsyncClientHook.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/special/CloseableHttpAsyncClientHook.java
@@ -1,0 +1,62 @@
+package rocks.inspectit.agent.java.sensor.method.special;
+
+import rocks.inspectit.agent.java.config.impl.SpecialSensorConfig;
+import rocks.inspectit.agent.java.hooking.ISpecialHook;
+import rocks.inspectit.agent.java.proxy.IRuntimeLinker;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.proxy.FutureCallbackProxy;
+import rocks.inspectit.agent.java.tracing.core.adapter.store.ApacheHttpContextSpanStoreAdapter;
+
+/**
+ * Hook that intercepts the execute method of the {@link CloseableHttpAsyncClient}.
+ *
+ * @author Isabel Vico Peinado
+ *
+ */
+public class CloseableHttpAsyncClientHook implements ISpecialHook {
+
+	/**
+	 * {@link IRuntimeLinker} used to proxy the interceptor of the class.
+	 */
+	private final IRuntimeLinker runtimeLinker;
+
+	/**
+	 * Default constructor.
+	 *
+	 * @param runtimeLinker
+	 *            Used for proxy the interceptor of the builder.
+	 */
+	public CloseableHttpAsyncClientHook(IRuntimeLinker runtimeLinker) {
+		this.runtimeLinker = runtimeLinker;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Object beforeBody(long methodId, Object object, Object[] parameters, SpecialSensorConfig ssc) {
+		if ((null != parameters) && (parameters.length == 4)) {
+			// the HTTP context
+			Object httpContext = parameters[2];
+
+			// the original callback given by the user
+			Object originalCallback = parameters[3];
+
+			SpanStoreAdapter spanStoreAdapter = new ApacheHttpContextSpanStoreAdapter(httpContext);
+
+			FutureCallbackProxy proxy = new FutureCallbackProxy(originalCallback, spanStoreAdapter);
+			Object newProxy = runtimeLinker.createProxy(FutureCallbackProxy.class, proxy, object.getClass().getClassLoader());
+
+			parameters[3] = newProxy;
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Object afterBody(long methodId, Object object, Object[] parameters, Object result, SpecialSensorConfig ssc) {
+		return null;
+	}
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/special/CloseableHttpAsyncClientSensor.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/sensor/method/special/CloseableHttpAsyncClientSensor.java
@@ -1,0 +1,48 @@
+package rocks.inspectit.agent.java.sensor.method.special;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import rocks.inspectit.agent.java.hooking.IHook;
+import rocks.inspectit.agent.java.hooking.ISpecialHook;
+import rocks.inspectit.agent.java.proxy.IRuntimeLinker;
+import rocks.inspectit.agent.java.sensor.method.AbstractMethodSensor;
+import rocks.inspectit.agent.java.sensor.method.IMethodSensor;
+
+/**
+ * Closeable HTTP asynchronous client sensor.
+ * 
+ * @author Isabel Vico Peinado
+ *
+ */
+public class CloseableHttpAsyncClientSensor extends AbstractMethodSensor implements IMethodSensor {
+
+	/**
+	 * Hook to use.
+	 */
+	private ISpecialHook hook;
+
+	/**
+	 * {@link IRuntimeLinked} used to build the hook for the closeable.
+	 */
+	@Autowired
+	private IRuntimeLinker runtimeLinker;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public IHook getHook() {
+		return hook;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected void initHook(Map<String, Object> parameters) {
+		hook = new CloseableHttpAsyncClientHook(runtimeLinker);
+	}
+
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/SpanStoreAdapter.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/SpanStoreAdapter.java
@@ -38,5 +38,10 @@ public interface SpanStoreAdapter {
 		 * Constant for span store key. Can be used for storing in maps or map like data structures.
 		 */
 		String ID = "rocks.inspectit.spanstore";
+
+		/**
+		 * Constant for the CANCEL tag which indicates whether an operation has been canceled.
+		 */
+		String CANCEL = "rocks.inspectit.cancel";
 	}
 }

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/http/HttpRequestAdapter.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/http/HttpRequestAdapter.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
@@ -55,7 +57,7 @@ public abstract class HttpRequestAdapter implements RequestAdapter<TextMap> {
 		}
 
 		Map<String, String> tags = new HashMap<String, String>(2, 1f);
-		if (null != url) {
+		if (StringUtils.isNotEmpty(url)) {
 			tags.put(Tags.HTTP_URL.getKey(), url);
 		}
 		if (null != method) {

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/http/proxy/FutureCallbackProxy.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/http/proxy/FutureCallbackProxy.java
@@ -1,0 +1,157 @@
+package rocks.inspectit.agent.java.tracing.core.adapter.http.proxy;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import rocks.inspectit.agent.java.eum.reflection.CachedMethod;
+import rocks.inspectit.agent.java.proxy.IProxySubject;
+import rocks.inspectit.agent.java.proxy.IRuntimeLinker;
+import rocks.inspectit.agent.java.proxy.ProxyFor;
+import rocks.inspectit.agent.java.proxy.ProxyMethod;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.TagsProvidingAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.error.ThrowableAwareResponseAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.HttpResponseAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.data.impl.ApacheHttpClientV40HttpResponse;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.agent.java.util.ReflectionCache;
+
+/**
+ * Proxy-class to wrap instances of the {@link org.apache.http.concurrent.FutureCallback} class.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+@ProxyFor(implementedInterfaces = "org.apache.http.concurrent.FutureCallback")
+public class FutureCallbackProxy implements IProxySubject {
+
+
+	/**
+	 * Reflection cache of this class.
+	 */
+	private static final ReflectionCache CACHE = new ReflectionCache();
+
+	/**
+	 * Span store adapter that provides a span store.
+	 */
+	private SpanStoreAdapter spanStoreAdapter;
+
+	/**
+	 * The original future callback.
+	 */
+	private Object originalCallback;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param originalCallback
+	 *            the original future callback
+	 * @param spanStoreAdapter
+	 *            Span store adapter that provides a span store.
+	 */
+	public FutureCallbackProxy(Object originalCallback, SpanStoreAdapter spanStoreAdapter) {
+		this.originalCallback = originalCallback;
+		this.spanStoreAdapter = spanStoreAdapter;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Object[] getProxyConstructorArguments() {
+		return new Object[0];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void proxyLinked(Object proxyObject, IRuntimeLinker linker) {
+	}
+
+	/**
+	 * Completed method for FutureCallback.
+	 *
+	 * @param response
+	 *            Response of the request.
+	 */
+	@ProxyMethod(parameterTypes = { "java.lang.Object" })
+	public void completed(Object response) {
+		try {
+			SpanStore spanStore = spanStoreAdapter.getSpanStore();
+			if (spanStore != null) {
+				spanStore.finishSpan(new HttpResponseAdapter(new ApacheHttpClientV40HttpResponse(response, CACHE)));
+			}
+		} finally {
+			if (originalCallback != null) {
+				WFutureCallback.completed.callSafe(originalCallback, response);
+			}
+		}
+	}
+
+	/**
+	 * Failed method of FutureCallback.
+	 *
+	 * @param exception
+	 *            Exception thrown when the request failed.
+	 */
+	@ProxyMethod(parameterTypes = { "java.lang.Exception" })
+	public void failed(Object exception) {
+		try {
+			SpanStore spanStore = spanStoreAdapter.getSpanStore();
+			if (spanStore != null) {
+				spanStore.finishSpan(new ThrowableAwareResponseAdapter(exception.getClass().getSimpleName()));
+			}
+		} finally {
+			if (originalCallback != null) {
+				WFutureCallback.failed.callSafe(originalCallback, exception);
+			}
+		}
+	}
+
+	/**
+	 * Cancelled method for FutureCallback.
+	 */
+	@ProxyMethod()
+	public void cancelled() {
+		try {
+			SpanStore spanStore = spanStoreAdapter.getSpanStore();
+			if (spanStore != null) {
+				spanStore.finishSpan(new TagsProvidingAdapter() {
+					@Override
+					public Map<String, String> getTags() {
+						return ImmutableMap.of(SpanStoreAdapter.Constants.CANCEL, "true");
+					}
+				});
+			}
+		} finally {
+			if (originalCallback != null) {
+				WFutureCallback.cancelled.callSafe(originalCallback);
+			}
+		}
+	}
+
+	/**
+	 * Reflection wrapper class for {@link org.apache.http.concurrent.FutureCallback}.
+	 */
+	static class WFutureCallback {
+
+		/**
+		 * See {@link org.apache.http.concurrent.FutureCallback#completed(java.lang.Object)}.
+		 */
+		static CachedMethod<Void> completed = new CachedMethod<Void>("org.apache.http.concurrent.FutureCallback", "completed", Object.class);
+
+		/**
+		 * See {@link org.apache.http.concurrent.FutureCallback#failed(java.lang.Exception)}.
+		 */
+		static CachedMethod<Void> failed = new CachedMethod<Void>("org.apache.http.concurrent.FutureCallback", "failed", Exception.class);
+
+		/**
+		 * See {@link org.apache.http.concurrent.FutureCallback#cancelled()}.
+		 */
+		static CachedMethod<Void> cancelled = new CachedMethod<Void>("org.apache.http.concurrent.FutureCallback", "cancelled");
+
+	}
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/store/ApacheHttpContextSpanStoreAdapter.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/tracing/core/adapter/store/ApacheHttpContextSpanStoreAdapter.java
@@ -1,0 +1,54 @@
+package rocks.inspectit.agent.java.tracing.core.adapter.store;
+
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.agent.java.util.ReflectionCache;
+
+/**
+ * {@link SpanStoreAdapter} for the Apache's HttpContext.
+ *
+ * @author Marius Oehler
+ *
+ */
+public class ApacheHttpContextSpanStoreAdapter implements SpanStoreAdapter {
+
+	/**
+	 * Reflection cache to use for method invocation.
+	 */
+	private final ReflectionCache cache = new ReflectionCache();
+
+	/**
+	 * The HTTP context to use for storing a span store.
+	 */
+	private final Object httpContext;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param httpContext
+	 *            the HTTP context to use for storing a span store
+	 */
+	public ApacheHttpContextSpanStoreAdapter(Object httpContext) {
+		this.httpContext = httpContext;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public SpanStore getSpanStore() {
+		Object spanStore = cache.invokeMethod(httpContext.getClass(), "getAttribute", new Class<?>[] { String.class }, httpContext, new Object[] { SpanStoreAdapter.Constants.ID }, null);
+		if (spanStore instanceof SpanStore) {
+			return (SpanStore) spanStore;
+		}
+		return null;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void setSpanStore(SpanStore spanStore) {
+		cache.invokeMethod(httpContext.getClass(), "setAttribute", new Class<?>[] { String.class, Object.class }, httpContext, new Object[] { SpanStoreAdapter.Constants.ID, spanStore }, null);
+	}
+}

--- a/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/util/AutoboxingHelper.java
+++ b/inspectit.agent.java/src/main/java/rocks/inspectit/agent/java/util/AutoboxingHelper.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  *
- * Helps with mapping of primtive types to their Boxed class and backwards.
+ * Helps with mapping of primitive types to their Boxed class and backwards.
  *
  * @author Jonas Kunz
  *

--- a/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/async/http/ApacheClientExchangeHandlerHookTest.java
+++ b/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/async/http/ApacheClientExchangeHandlerHookTest.java
@@ -1,0 +1,129 @@
+package rocks.inspectit.agent.java.sensor.method.async.http;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.testng.annotations.Test;
+
+import rocks.inspectit.agent.java.config.impl.RegisteredSensorConfig;
+import rocks.inspectit.agent.java.core.ICoreService;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.shared.all.testbase.TestBase;
+
+/**
+ * Tests the {@link ApacheClientExchangeHandlerHook} class.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+@SuppressWarnings("PMD")
+public class ApacheClientExchangeHandlerHookTest extends TestBase {
+
+	@InjectMocks
+	ApacheClientExchangeHandlerHook hook;
+
+	@Mock
+	RegisteredSensorConfig rsc;
+
+	AbstractClientExchangeHandler handler = new AbstractClientExchangeHandler();
+
+	/**
+	 * Tests the
+	 * {@link ApacheClientExchangeHandlerHook#beforeBody(long, long, Object, Object[], RegisteredSensorConfig)}
+	 * method.
+	 */
+	public static class BeforeBody extends ApacheClientExchangeHandlerHookTest {
+
+		@Test
+		public void successful() {
+			SpanStore spanStore = mock(SpanStore.class);
+			HttpContext context = mock(HttpContext.class);
+			when(context.getAttribute(SpanStoreAdapter.Constants.ID)).thenReturn(spanStore);
+			handler.localContext = context;
+
+			hook.beforeBody(5L, 10L, handler, null, rsc);
+
+			verify(context).getAttribute(SpanStoreAdapter.Constants.ID);
+			verify(spanStore).startSpan();
+			verifyNoMoreInteractions(spanStore, context);
+			verifyZeroInteractions(rsc);
+		}
+
+		@Test
+		public void noSpanStore() {
+			HttpContext context = mock(HttpContext.class);
+			handler.localContext = context;
+
+			hook.beforeBody(5L, 10L, handler, null, rsc);
+
+			verify(context).getAttribute(SpanStoreAdapter.Constants.ID);
+			verifyNoMoreInteractions(context);
+			verifyZeroInteractions(rsc);
+		}
+
+		@Test
+		public void missingHttpContext() {
+			hook.beforeBody(5L, 10L, handler, null, rsc);
+
+			verifyZeroInteractions(rsc);
+		}
+	}
+
+	/**
+	 * Tests the
+	 * {@link ApacheClientExchangeHandlerHook#firstAfterBody(long, long, Object, Object[], Object, boolean, rocks.inspectit.agent.java.config.impl.RegisteredSensorConfig)}
+	 * method.
+	 */
+	public static class FirstAfterBody extends ApacheClientExchangeHandlerHookTest {
+
+		@Test
+		public void successful() {
+			Object result = mock(Object.class);
+
+			hook.firstAfterBody(5L, 10L, handler, null, result, false, rsc);
+
+			verifyZeroInteractions(rsc, result);
+		}
+	}
+
+	/**
+	 * Tests the
+	 * {@link ApacheClientExchangeHandlerHook#secondAfterBody(rocks.inspectit.agent.java.core.ICoreService, long, long, Object, Object[], Object, boolean, RegisteredSensorConfig)}
+	 * method.
+	 */
+	public static class SecondAfterBody extends ApacheClientExchangeHandlerHookTest {
+
+		@Test
+		public void successful() {
+			ICoreService coreService = mock(ICoreService.class);
+			Object result = mock(Object.class);
+
+			hook.secondAfterBody(coreService, 5L, 10L, handler, null, result, false, rsc);
+
+			verifyZeroInteractions(coreService, rsc, result);
+		}
+	}
+
+	/**
+	 * Mock template for {@link org.apache.http.protocol.HttpContext}.
+	 */
+	interface HttpContext {
+		Object getAttribute(String id);
+	}
+
+	/**
+	 * Dummy class representing
+	 * {@link org.apache.http.impl.nio.client.AbstractClientExchangeHandler}.
+	 */
+	@SuppressWarnings("unused")
+	class AbstractClientExchangeHandler {
+		private HttpContext localContext;
+	}
+}

--- a/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/remote/client/http/ApacheAsyncHttpClientSensorTest.java
+++ b/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/remote/client/http/ApacheAsyncHttpClientSensorTest.java
@@ -1,0 +1,143 @@
+package rocks.inspectit.agent.java.sensor.method.remote.client.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import io.opentracing.References;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.tag.Tags;
+import rocks.inspectit.agent.java.config.impl.RegisteredSensorConfig;
+import rocks.inspectit.agent.java.tracing.core.adapter.AsyncClientRequestAdapter;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.shared.all.testbase.TestBase;
+import rocks.inspectit.shared.all.tracing.data.PropagationType;
+
+/**
+ * @author Isabel Vico Peinado
+ *
+ */
+@SuppressWarnings("PMD")
+public class ApacheAsyncHttpClientSensorTest extends TestBase {
+
+	@InjectMocks
+	ApacheAsyncHttpClientSensor sensor;
+
+	@Mock
+	RegisteredSensorConfig rsc;
+
+	public static class GetAsyncClientRequestAdapter extends ApacheAsyncHttpClientSensorTest {
+
+		@Mock
+		Object object;
+
+		@Mock
+		HttpRequest httpRequest;
+
+		@Mock
+		RequestLine requestLine;
+
+		@Mock
+		HttpContext httpContext;
+
+		@Mock
+		SpanStore spanStore;
+
+		@BeforeMethod
+		public void init() {
+			when(httpRequest.getRequestLine()).thenReturn(requestLine);
+		}
+
+		@Test
+		public void mustHaveTheProperProperties() {
+			AsyncClientRequestAdapter<TextMap> adapter = sensor.getAsyncClientRequestAdapter(object, new Object[] { null, httpRequest, httpContext, null }, rsc);
+
+			assertThat("The propagation type must be HTTP.", adapter.getPropagationType(), is(PropagationType.HTTP));
+			assertThat("The reference type must be FOLLOWS FROM.", adapter.getReferenceType(), is(References.FOLLOWS_FROM));
+			assertThat("The format must be HTTP HEADER.", adapter.getFormat(), is(Format.Builtin.HTTP_HEADERS));
+			verifyZeroInteractions(object, rsc);
+		}
+
+		@Test
+		public void mustStartClientProperlyWhenTheRequestDoesNotContainsHeader() {
+			when(httpRequest.containsHeader(anyString())).thenReturn(false);
+
+			AsyncClientRequestAdapter<TextMap> adapter = sensor.getAsyncClientRequestAdapter(object, new Object[] { null, httpRequest, httpContext, null }, rsc);
+
+			assertThat("The client must be started.", adapter.startClientSpan(), is(true));
+		}
+
+		@Test
+		public void mustHaveOneTagWithTheExpectedUri() {
+			String uri = "uri";
+			when(requestLine.getUri()).thenReturn(uri);
+
+			AsyncClientRequestAdapter<TextMap> adapter = sensor.getAsyncClientRequestAdapter(object, new Object[] { null, httpRequest, httpContext, null }, rsc);
+
+			Map<String, String> tags = adapter.getTags();
+			assertThat("Tags map size must be 1.", tags.size(), is(1));
+			assertThat("Tags map must have the expected uri.", tags, hasEntry(Tags.HTTP_URL.getKey(), uri));
+			verifyZeroInteractions(object, rsc);
+		}
+
+		@Test
+		public void mustHaveOneTagWithTheExpectedMethod() {
+			String methodName = "get";
+			when(requestLine.getMethod()).thenReturn(methodName);
+
+			AsyncClientRequestAdapter<TextMap> adapter = sensor.getAsyncClientRequestAdapter(object, new Object[] { null, httpRequest, httpContext, null }, rsc);
+
+			Map<String, String> tags = adapter.getTags();
+			assertThat("Tags map size must be 1.", tags.size(), is(1));
+			assertThat("Tags map must have the expected method name.", tags, hasEntry(Tags.HTTP_METHOD.getKey(), methodName));
+			verifyZeroInteractions(object, rsc);
+		}
+
+		@Test
+		public void mustNotHaveAnyTagWhenRequestLineIsNull() {
+			when(httpRequest.getRequestLine()).thenReturn(null);
+
+			AsyncClientRequestAdapter<TextMap> adapter = sensor.getAsyncClientRequestAdapter(object, new Object[] { null, httpRequest, httpContext, null }, rsc);
+
+			Map<String, String> tags = adapter.getTags();
+			assertThat("Tags map size must be 0.", tags.size(), is(0));
+			verifyZeroInteractions(object, rsc);
+		}
+
+	}
+
+	interface HttpRequest {
+		RequestLine getRequestLine();
+
+		void setHeader(String key, String value);
+
+		boolean containsHeader(String key);
+	};
+
+
+	interface RequestLine {
+		String getUri();
+
+		String getMethod();
+	};
+
+	interface HttpContext {
+		Object getAttribute(String id);
+
+		void setAttribute(String id, Object obj);
+
+		Object removeAttribute(String id);
+	}
+
+}

--- a/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/special/CloseableHttpAsyncClientHookTest.java
+++ b/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/special/CloseableHttpAsyncClientHookTest.java
@@ -1,0 +1,158 @@
+package rocks.inspectit.agent.java.sensor.method.special;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.theInstance;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import rocks.inspectit.agent.java.config.impl.SpecialSensorConfig;
+import rocks.inspectit.agent.java.proxy.IRuntimeLinker;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.proxy.FutureCallbackProxy;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.shared.all.testbase.TestBase;
+
+/**
+ * Tests the {@link CloseableHttpAsyncClientHook} class.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+@SuppressWarnings("PMD")
+public class CloseableHttpAsyncClientHookTest extends TestBase {
+
+	@InjectMocks
+	CloseableHttpAsyncClientHook hook;
+
+	@Mock
+	SpecialSensorConfig ssc;
+
+	@Mock
+	Object object;
+
+	@Mock
+	IRuntimeLinker runtimeLinker;
+
+	/**
+	 * Tests the
+	 * {@link CloseableHttpAsyncClientHook#beforeBody(long, Object, Object[], SpecialSensorConfig)}
+	 * method.
+	 */
+	public static class BeforeBody extends CloseableHttpAsyncClientHookTest {
+
+		static final long METHOD_ID = 11L;
+
+		@Mock
+		HttpContext httpContext;
+
+		@Mock
+		FutureCallback futureCallback;
+
+		@Test
+		public void successful() {
+			SpanStore spanStore = new SpanStore();
+			Object[] parameters = new Object[] { new Object(), new Object(), httpContext, mock(FutureCallback.class) };
+			when(runtimeLinker.createProxy(eq(FutureCallbackProxy.class), Mockito.<FutureCallbackProxy> any(), Mockito.<ClassLoader> any())).thenReturn(futureCallback);
+			when(httpContext.getAttribute(SpanStoreAdapter.Constants.ID)).thenReturn(spanStore);
+			ArgumentCaptor<FutureCallbackProxy> proxyCaptor = ArgumentCaptor.forClass(FutureCallbackProxy.class);
+
+			Object result = hook.beforeBody(METHOD_ID, object, parameters, ssc);
+
+			verify(runtimeLinker).createProxy(eq(FutureCallbackProxy.class), proxyCaptor.capture(), Mockito.<ClassLoader> any());
+			verifyNoMoreInteractions(runtimeLinker, httpContext);
+			verifyZeroInteractions(ssc, object, futureCallback, httpContext);
+			assertThat(result, is(nullValue()));
+			assertThat(parameters[3], is(theInstance((Object) futureCallback)));
+		}
+
+		@Test
+		public void mustNotHaveAProxyInThirdParametersIfThereIsNoParameters() {
+			Object[] parameters = new Object[] {};
+
+			hook.beforeBody(METHOD_ID, object, parameters, ssc);
+
+			verifyNoMoreInteractions(runtimeLinker);
+			verifyZeroInteractions(ssc, object, httpContext, futureCallback);
+		}
+
+		@Test
+		public void mustNotHaveAProxyInThirdParametersIfParametersIsNull() {
+			Object[] parameters = null;
+
+			hook.beforeBody(METHOD_ID, object, parameters, ssc);
+
+			verifyNoMoreInteractions(runtimeLinker);
+			verifyZeroInteractions(ssc, object, httpContext, futureCallback);
+		}
+
+		@Test
+		public void mustNotSetProxyIfThereIsTooManyParameters() {
+			Object[] parameters = new String[] { null, null, null, null, null };
+
+			hook.beforeBody(METHOD_ID, object, parameters, ssc);
+
+			assertThat("Third parameter (proxy) must not be set.", parameters[3], is(nullValue()));
+			verifyNoMoreInteractions(runtimeLinker);
+			verifyZeroInteractions(ssc, object, httpContext, futureCallback);
+		}
+
+		@Test
+		public void mustNotSetProxyIfThereIsTooFewParameters() {
+			Object[] parameters = new String[] { null, null, null };
+
+			hook.beforeBody(METHOD_ID, object, parameters, ssc);
+
+			verifyNoMoreInteractions(runtimeLinker);
+			verifyZeroInteractions(ssc, object, httpContext, futureCallback);
+		}
+
+		interface FutureCallback {
+			void completed(Object response);
+
+			void failed(Object exception);
+
+			void cancelled();
+		}
+
+		interface HttpContext {
+			Object getAttribute(String id);
+
+			void setAttribute(String id, Object obj);
+
+			Object removeAttribute(String id);
+		}
+	}
+
+	/**
+	 * Tests the
+	 * {@link CloseableHttpAsyncClientHook#afterBody(long, Object, Object[], Object, SpecialSensorConfig)}
+	 * method.
+	 */
+	public static class AfterBody extends CloseableHttpAsyncClientHookTest {
+
+		@Test
+		public void returnsANullValueAndHasZeroInteractionsWithAnyOfTheParamters() {
+			long methodId = 11L;
+			Object[] parameters = new Object[0];
+			Object result = mock(Object.class);
+
+			Object afterBodyObject = hook.afterBody(methodId, object, parameters, result, ssc);
+
+			assertThat("The returned object after body must be null.", afterBodyObject, is(nullValue()));
+			verifyZeroInteractions(object, result, ssc, runtimeLinker);
+		}
+	}
+}

--- a/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/special/EUMInstrumentationHookTest.java
+++ b/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/sensor/method/special/EUMInstrumentationHookTest.java
@@ -45,6 +45,7 @@ import rocks.inspectit.shared.all.testbase.TestBase;
  * @author Jonas Kunz
  *
  */
+@SuppressWarnings("PMD")
 public class EUMInstrumentationHookTest extends TestBase {
 
 	AgentEndUserMonitoringConfig eumConfig = new AgentEndUserMonitoringConfig();

--- a/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/tracing/core/adapter/http/proxy/FutureCallbackProxyTest.java
+++ b/inspectit.agent.java/src/test/java/rocks/inspectit/agent/java/tracing/core/adapter/http/proxy/FutureCallbackProxyTest.java
@@ -1,0 +1,212 @@
+package rocks.inspectit.agent.java.tracing.core.adapter.http.proxy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import rocks.inspectit.agent.java.eum.reflection.CachedMethod;
+import rocks.inspectit.agent.java.tracing.core.adapter.SpanStoreAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.TagsProvidingAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.HttpResponseAdapter;
+import rocks.inspectit.agent.java.tracing.core.adapter.http.proxy.FutureCallbackProxy.WFutureCallback;
+import rocks.inspectit.agent.java.tracing.core.async.SpanStore;
+import rocks.inspectit.shared.all.testbase.TestBase;
+
+/**
+ * Tests the {@link FutureCallbackProxy} class.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+@SuppressWarnings("PMD")
+public class FutureCallbackProxyTest extends TestBase {
+
+	@InjectMocks
+	FutureCallbackProxy proxy;
+
+	@Mock
+	SpanStoreAdapter spanStoreAdapter;
+
+	@Mock
+	SpanStore spanStore;
+
+	@Mock
+	FutureCallback originalCallback;
+
+	@BeforeMethod
+	public void init() throws Exception {
+		proxy = new FutureCallbackProxy(originalCallback, spanStoreAdapter);
+
+		WFutureCallback.completed = new CachedMethod<Void>(FutureCallback.class.getName(), "completed", Object.class);
+		WFutureCallback.failed = new CachedMethod<Void>(FutureCallback.class.getName(), "failed", Exception.class);
+		WFutureCallback.cancelled = new CachedMethod<Void>(FutureCallback.class.getName(), "cancelled");
+	}
+
+	public void removeOriginalCallback() throws Exception {
+		Field fieldCallback = FutureCallbackProxy.class.getDeclaredField("originalCallback");
+		fieldCallback.setAccessible(true);
+		fieldCallback.set(proxy, null);
+	}
+
+	/**
+	 * Tests the {@link FutureCallbackProxy#getProxyConstructorArguments()} method.
+	 */
+	public static class GetProxyConstructorArguments extends FutureCallbackProxyTest {
+
+		@Test
+		public void returnsAnEmptyCollection() {
+			Object[] args = proxy.getProxyConstructorArguments();
+
+			assertThat("Number of args returned by the constructor must be zero.", args, is(new Object[] {}));
+		}
+	}
+
+	/**
+	 * Tests the {@link FutureCallbackProxy#completed(Object)} method.
+	 */
+	public static class Completed extends FutureCallbackProxyTest {
+
+		@Test
+		public void successful() {
+			Object response = new Object();
+			when(spanStoreAdapter.getSpanStore()).thenReturn(spanStore);
+
+			proxy.completed(response);
+
+			verify(spanStoreAdapter).getSpanStore();
+			verify(spanStore).finishSpan((HttpResponseAdapter) any());
+			verify(originalCallback).completed(response);
+			verifyNoMoreInteractions(spanStore, spanStoreAdapter, originalCallback);
+		}
+
+		@Test
+		public void withoutSpanStore() {
+			Object response = new Object();
+
+			proxy.completed(response);
+
+			verify(spanStoreAdapter).getSpanStore();
+			verify(originalCallback).completed(response);
+			verifyNoMoreInteractions(spanStoreAdapter, originalCallback);
+			verifyZeroInteractions(spanStore);
+		}
+
+		@Test
+		public void withoutSpanStoreAndCallback() throws Exception {
+			Object response = new Object();
+			removeOriginalCallback();
+
+			proxy.completed(response);
+
+			verify(spanStoreAdapter).getSpanStore();
+			verifyNoMoreInteractions(spanStoreAdapter);
+			verifyZeroInteractions(spanStore, originalCallback);
+		}
+	}
+
+	/**
+	 * Tests the {@link FutureCallbackProxy#failed(Object)} method.
+	 */
+	public static class Failed extends FutureCallbackProxyTest {
+
+		@Test
+		public void successful() throws Exception {
+			Exception exception = new Exception();
+			when(spanStoreAdapter.getSpanStore()).thenReturn(spanStore);
+
+			proxy.failed(exception);
+
+			verify(spanStoreAdapter).getSpanStore();
+			verify(spanStore).finishSpan((TagsProvidingAdapter) any());
+			verify(originalCallback).failed(exception);
+			verifyNoMoreInteractions(spanStore, spanStoreAdapter, originalCallback);
+		}
+
+		@Test
+		public void withoutSpanStore() throws Exception {
+			Exception exception = new Exception();
+
+			proxy.failed(exception);
+
+			verify(spanStoreAdapter).getSpanStore();
+			verify(originalCallback).failed(exception);
+			verifyNoMoreInteractions(spanStoreAdapter, originalCallback);
+			verifyZeroInteractions(spanStore);
+		}
+
+		@Test
+		public void withoutSpanStoreAndCallback() throws Exception {
+			Exception exception = new Exception();
+			removeOriginalCallback();
+
+			proxy.failed(exception);
+
+			verify(spanStoreAdapter).getSpanStore();
+			verifyNoMoreInteractions(spanStoreAdapter);
+			verifyZeroInteractions(spanStore, originalCallback);
+		}
+	}
+
+	/**
+	 * Tests the {@link FutureCallbackProxy#cancelled()} method.
+	 */
+	public static class Cancelled extends FutureCallbackProxyTest {
+
+		@Test
+		public void successful() throws Exception {
+			when(spanStoreAdapter.getSpanStore()).thenReturn(spanStore);
+
+			proxy.cancelled();
+
+			ArgumentCaptor<TagsProvidingAdapter> captor = ArgumentCaptor.forClass(TagsProvidingAdapter.class);
+			verify(spanStoreAdapter).getSpanStore();
+			verify(spanStore).finishSpan(captor.capture());
+			verify(originalCallback).cancelled();
+			verifyNoMoreInteractions(spanStore, spanStoreAdapter, originalCallback);
+			assertThat(captor.getValue().getTags(), hasKey(SpanStoreAdapter.Constants.CANCEL));
+		}
+
+		@Test
+		public void withoutSpanStore() throws Exception {
+			proxy.cancelled();
+
+			verify(spanStoreAdapter).getSpanStore();
+			verify(originalCallback).cancelled();
+			verifyNoMoreInteractions(spanStoreAdapter, originalCallback);
+			verifyZeroInteractions(spanStore);
+		}
+
+		@Test
+		public void withoutSpanStoreAndCallback() throws Exception {
+			removeOriginalCallback();
+
+			proxy.cancelled();
+
+			verify(spanStoreAdapter).getSpanStore();
+			verifyNoMoreInteractions(spanStoreAdapter);
+			verifyZeroInteractions(spanStore, originalCallback);
+		}
+	}
+
+	public interface FutureCallback {
+		void completed(Object object);
+
+		void failed(Exception object);
+
+		void cancelled();
+	}
+}

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/ejb_v2.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/ejb_v2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="ejb_v2" name="EJB v2" common="true" created-on="2015-02-24T12:00:00" description="Profile for the EJBs (versions 1.x and 2.x)."
+<profile schemaVersion="8" id="ejb_v2" name="EJB v2" common="true" created-on="2015-02-24T12:00:00" description="Profile for the EJBs (versions 1.x and 2.x)."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- Configuration for EJB v. < 3 -->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/ejb_v3.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/ejb_v3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="ejb_v3" name="EJB v3" common="true" created-on="2015-02-24T12:00:00" description="Profile for the EJBs version 3.x."
+<profile schemaVersion="8" id="ejb_v3" name="EJB v3" common="true" created-on="2015-02-24T12:00:00" description="Profile for the EJBs version 3.x."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- Configuration for EJB v. 3 -->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/exclude-classes.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/exclude-classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="exclude-classes" name="Exclude Classes" common="true" default="true" created-on="2015-02-24T12:00:00" description="Default exclude rules, should be included in every Environment."
+<profile schemaVersion="8" id="exclude-classes" name="Exclude Classes" common="true" default="true" created-on="2015-02-24T12:00:00" description="Default exclude rules, should be included in every Environment."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<exclude-rules-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/executor-correlation.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/executor-correlation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="executor-correlation" name="Executor Correlation" common="true" default="true" created-on="2017-08-11T12:00:00" description="Profile for the correlation of Executors"
+<profile schemaVersion="8" id="executor-correlation" name="Executor Correlation" common="true" default="true" created-on="2017-08-11T12:00:00" description="Profile for the correlation of Executors"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 	
     <!-- executor correlation -->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/hibernate.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/hibernate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="hibernate" name="Hibernate" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Hibernate framework."
+<profile schemaVersion="8" id="hibernate" name="Hibernate" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Hibernate framework."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- Hibernate-->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/http.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="http" name="HTTP" common="true" default="true" created-on="2015-02-24T12:00:00" description="Profile for the HTTP calls."
+<profile schemaVersion="8" id="http" name="HTTP" common="true" default="true" created-on="2015-02-24T12:00:00" description="Profile for the HTTP calls."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- Http -->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/jpa.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/jpa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="jpa" name="JPA" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Java Persistance API."
+<profile schemaVersion="8" id="jpa" name="JPA" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Java Persistance API."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- JPA-->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/jsf.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/jsf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="jsf" name="JSF" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Java Server Faces."
+<profile schemaVersion="8" id="jsf" name="JSF" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Java Server Faces."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/jta.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/jta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="jta" name="JTA" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Java Transaction API."
+<profile schemaVersion="8" id="jta" name="JTA" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Java Transaction API."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/logging-log4j.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/logging-log4j.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="logging-log4j" name="Logging for log4j" common="true" created-on="2016-01-29T12:00:00" description="Profile for the log4j logging capturing."
+<profile schemaVersion="8" id="logging-log4j" name="Logging for log4j" common="true" created-on="2016-01-29T12:00:00" description="Profile for the log4j logging capturing."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- Configuration for Log4j -->

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/remote-http.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/remote-http.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="remote-http" name="Remote-HTTP" common="true" default="true" created-on="2016-11-24T12:00:00" description="Profile for the Remote HTTP Calls."
+<profile schemaVersion="8" id="remote-http" name="Remote-HTTP" common="true" default="true" created-on="2016-11-24T12:00:00" description="Profile for the Remote HTTP Calls."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>
 		<!-- Client sensor for Apache HttpClient 4.3 and above-->
 		<method-sensor-assignment sensor-config-class="rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig" class-name="org.apache.http.impl.client.CloseableHttpClient" method-name="doExecute" parameters="org.apache.http.HttpHost org.apache.http.HttpRequest org.apache.http.protocol.HttpContext" superclass="true" />
 
-		<!-- Client sensor for  Apache HttpClient 4.0 - 4.2.x-->
+		<!-- Client sensor for Apache HttpClient 4.0 - 4.2.x-->
 		<method-sensor-assignment sensor-config-class="rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig" class-name="org.apache.http.client.HttpClient" method-name="execute" parameters="org.apache.http.HttpHost org.apache.http.HttpRequest org.apache.http.protocol.HttpContext" interface="true" />
 		<method-sensor-assignment sensor-config-class="rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig" class-name="org.apache.http.client.RequestDirector" method-name="execute" parameters="org.apache.http.HttpHost org.apache.http.HttpRequest org.apache.http.protocol.HttpContext" interface="true" />
+
+		<!-- Client sensors for Apache Async HttpClient 4.x-->
+		<method-sensor-assignment sensor-config-class="rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteAsyncApacheHttpClientSensorConfig" class-name="org.apache.http.nio.client.HttpAsyncClient" method-name="execute" parameters="org.apache.http.HttpHost org.apache.http.HttpRequest org.apache.http.protocol.HttpContext org.apache.http.concurrent.FutureCallback" interface="true"/>
+		<method-sensor-assignment sensor-config-class="rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig" class-name="org.apache.http.impl.nio.client.AbstractClientExchangeHandler" method-name="generateRequest" parameters="" superclass="true"/>
 
 		<!-- Client sensor for Java HttpURLConnection-->
 		<method-sensor-assignment sensor-config-class="rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteUrlConnectionClientSensorConfig" class-name="java.net.HttpURLConnection" method-name="connect" parameters="" superclass="true" />

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/remote-jms.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/remote-jms.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7"  id="remote-jms" name="Remote-JMS" common="true" default="true" created-on="2016-11-24T12:00:00" description="Profile for the Remote JMS Calls."
+<profile schemaVersion="8"  id="remote-jms" name="Remote-JMS" common="true" default="true" created-on="2016-11-24T12:00:00" description="Profile for the Remote JMS Calls."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/sql-parameters.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/sql-parameters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="sql-parameters" name="SQL Parameters" common="true" created-on="2015-02-24T12:00:00" description="Profile for the SQL statement parameter values."
+<profile schemaVersion="8" id="sql-parameters" name="SQL Parameters" common="true" created-on="2015-02-24T12:00:00" description="Profile for the SQL statement parameter values."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/sql.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/sql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="sql" name="SQL" common="true" default="true" created-on="2015-02-24T12:00:00" description="Profile for the SQL statements."
+<profile schemaVersion="8" id="sql" name="SQL" common="true" default="true" created-on="2015-02-24T12:00:00" description="Profile for the SQL statements."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/struts.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/struts.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="struts" name="Struts" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Struts framework."
+<profile schemaVersion="8" id="struts" name="Struts" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Struts framework."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/trinidad.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/trinidad.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="trinidad" name="Trinidad JSF" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Apache MyFaces Trinidad JSF framework."
+<profile schemaVersion="8" id="trinidad" name="Trinidad JSF" common="true" created-on="2015-02-24T12:00:00" description="Profile for the Apache MyFaces Trinidad JSF framework."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/webservice.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/webservice.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="webservice" name="WebService" common="true" created-on="2015-02-24T12:00:00" description="Profile for the WebService calls."
+<profile schemaVersion="8" id="webservice" name="WebService" common="true" created-on="2015-02-24T12:00:00" description="Profile for the WebService calls."
 	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<sensor-assignment-profile-data>

--- a/inspectit.server/src/main/external-resources/ci/profiles/common/websocket.xml
+++ b/inspectit.server/src/main/external-resources/ci/profiles/common/websocket.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<profile schemaVersion="7" id="websockets" name="WebSocket" common="true" created-on="2016-09-02T21:25:23.839+02:00" description="Profile for the WebSocket calls." xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<profile schemaVersion="8" id="websockets" name="WebSocket" common="true" created-on="2016-09-02T21:25:23.839+02:00" description="Profile for the WebSocket calls." xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../schema/ciSchema.xsd">
 
 	<!-- Configuration for WebSeockets --> 

--- a/inspectit.server/src/main/external-resources/ci/schema/ciSchema.xsd
+++ b/inspectit.server/src/main/external-resources/ci/schema/ciSchema.xsd
@@ -11,6 +11,8 @@
 
   <xs:element name="and" type="andExpression"/>
 
+  <xs:element name="apache-client-exchange-handler-sensor" type="apacheClientExchangeHandlerSensorConfig"/>
+
   <xs:element name="applicaction" type="applicationDefinition"/>
 
   <xs:element name="boolean" type="booleanExpression"/>
@@ -104,6 +106,8 @@
   <xs:element name="profile" type="profile"/>
 
   <xs:element name="remote-apache-httpclientV40-client-sensor-config" type="remoteApacheHttpClientV40SensorConfig"/>
+
+  <xs:element name="remote-async-apache-httpclient-sensor-config" type="remoteAsyncApacheHttpClientSensorConfig"/>
 
   <xs:element name="remote-http-server-sensor-config" type="remoteJavaHttpServerSensorConfig"/>
 
@@ -528,11 +532,13 @@
                   <xs:element ref="remote-http-server-sensor-config"/>
                   <xs:element ref="remote-jms-listener-server-sensor-config"/>
                   <xs:element ref="remote-apache-httpclientV40-client-sensor-config"/>
+                  <xs:element ref="remote-async-apache-httpclient-sensor-config"/>
                   <xs:element ref="remote-urlconnection-client-sensor-config"/>
                   <xs:element ref="remote-jetty-httpclientV61-client-sensor-config"/>
                   <xs:element ref="remote-spring-resttemplate-client-sensor-config"/>
                   <xs:element ref="remote-jms-client-sensor-config"/>
                   <xs:element ref="remote-manual-server-sensor-config"/>
+                  <xs:element ref="apache-client-exchange-handler-sensor"/>
                 </xs:choice>
               </xs:sequence>
             </xs:complexType>
@@ -736,6 +742,14 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="remoteAsyncApacheHttpClientSensorConfig">
+    <xs:complexContent>
+      <xs:extension base="abstractRemoteSensorConfig">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
   <xs:complexType name="remoteUrlConnectionClientSensorConfig">
     <xs:complexContent>
       <xs:extension base="abstractRemoteSensorConfig">
@@ -771,6 +785,14 @@
   <xs:complexType name="remoteManualServerSensorConfig">
     <xs:complexContent>
       <xs:extension base="abstractRemoteSensorConfig">
+        <xs:sequence/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="apacheClientExchangeHandlerSensorConfig" final="extension restriction">
+    <xs:complexContent>
+      <xs:extension base="abstractMethodSensorConfig">
         <xs:sequence/>
       </xs:extension>
     </xs:complexContent>
@@ -1016,6 +1038,14 @@
             </xs:complexType>
           </xs:element>
         </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="closeableHttpAsyncClientSensorConfig" final="extension restriction">
+    <xs:complexContent>
+      <xs:extension base="abstractMethodSensorConfig">
+        <xs:sequence/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/inspectit.server/src/main/external-resources/ci/schema/migration/0008-added-apache-async-sensor.xml
+++ b/inspectit.server/src/main/external-resources/ci/schema/migration/0008-added-apache-async-sensor.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!-- In this update we'll add the apache async http client sensor to existing environment(s)-->
+
+	<!--Copy all -->
+	<xsl:template match="@*|node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()" />
+		</xsl:copy>
+	</xsl:template>
+
+	<!--Add apache async sensor type to method-sensor-configs -->
+	<xsl:template match="environment/method-sensor-configs">
+		<xsl:copy>
+			<xsl:apply-templates select="@* | node()"/>
+			<xsl:element name="remote-async-apache-httpclient-sensor-config"/>
+			<xsl:element name="apache-client-exchange-handler-sensor"/>
+		</xsl:copy>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/inspectit.server/src/main/java/rocks/inspectit/server/instrumentation/config/ConfigurationCreator.java
+++ b/inspectit.server/src/main/java/rocks/inspectit/server/instrumentation/config/ConfigurationCreator.java
@@ -25,6 +25,7 @@ import rocks.inspectit.shared.cs.ci.sensor.exception.IExceptionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.jmx.JmxSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.IMethodSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ClassLoadingDelegationSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.CloseableHttpAsyncClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.EUMInstrumentationSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ExecutorIntercepterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.MBeanServerInterceptorSensorConfig;
@@ -118,6 +119,7 @@ public class ConfigurationCreator {
 		}
 
 		specialMethodSensorTypeConfigs.add(getMethodSensorTypeConfig(platformId, ExecutorIntercepterSensorConfig.INSTANCE));
+		specialMethodSensorTypeConfigs.add(getMethodSensorTypeConfig(platformId, CloseableHttpAsyncClientSensorConfig.INSTANCE));
 
 		agentConfiguration.setSpecialMethodSensorTypeConfigs(specialMethodSensorTypeConfigs);
 

--- a/inspectit.server/src/test/java/rocks/inspectit/server/instrumentation/config/ConfigurationCreatorTest.java
+++ b/inspectit.server/src/test/java/rocks/inspectit/server/instrumentation/config/ConfigurationCreatorTest.java
@@ -27,6 +27,8 @@ import org.mockito.Mock;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Iterators;
+
 import rocks.inspectit.shared.all.instrumentation.config.PriorityEnum;
 import rocks.inspectit.shared.all.instrumentation.config.impl.AgentConfig;
 import rocks.inspectit.shared.all.instrumentation.config.impl.AgentEndUserMonitoringConfig;
@@ -47,6 +49,7 @@ import rocks.inspectit.shared.cs.ci.sensor.exception.IExceptionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.jmx.JmxSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.IMethodSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ClassLoadingDelegationSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.CloseableHttpAsyncClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ExecutorIntercepterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.MBeanServerInterceptorSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.platform.IPlatformSensorConfig;
@@ -70,6 +73,8 @@ public class ConfigurationCreatorTest extends TestBase {
 
 	public ExecutorIntercepterSensorConfig eisc = ExecutorIntercepterSensorConfig.INSTANCE;
 
+	public CloseableHttpAsyncClientSensorConfig closeableHttpAsyncCLient = CloseableHttpAsyncClientSensorConfig.INSTANCE;
+
 	@BeforeMethod
 	public void setup() {
 		// mock strategies
@@ -87,6 +92,7 @@ public class ConfigurationCreatorTest extends TestBase {
 
 			assertThat(agentConfiguration.getPlatformId(), is(agentId));
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -114,6 +120,7 @@ public class ConfigurationCreatorTest extends TestBase {
 
 			verify(registrationService).registerPlatformSensorTypeIdent(agentId, className);
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -130,6 +137,7 @@ public class ConfigurationCreatorTest extends TestBase {
 			assertThat(sensorTypeConfigs, is(empty()));
 
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -161,6 +169,7 @@ public class ConfigurationCreatorTest extends TestBase {
 
 			verify(registrationService).registerMethodSensorTypeIdent(agentId, className, parameters);
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -189,6 +198,7 @@ public class ConfigurationCreatorTest extends TestBase {
 
 			verify(registrationService).registerMethodSensorTypeIdent(agentId, className, parameters);
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -215,7 +225,7 @@ public class ConfigurationCreatorTest extends TestBase {
 
 			verify(registrationService).registerJmxSensorTypeIdent(agentId, className);
 			// needed because of the intercepting server sensor
-			verify(registrationService, times(2)).registerMethodSensorTypeIdent(anyLong(), anyString(), anyMap());
+			verify(registrationService, times(3)).registerMethodSensorTypeIdent(anyLong(), anyString(), anyMap());
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -232,6 +242,7 @@ public class ConfigurationCreatorTest extends TestBase {
 			assertThat(sensorTypeConfig, is(nullValue()));
 
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -270,8 +281,8 @@ public class ConfigurationCreatorTest extends TestBase {
 			AgentConfig agentConfiguration = creator.environmentToConfiguration(environment, agentId);
 
 			Collection<MethodSensorTypeConfig> sensorTypeConfigs = agentConfiguration.getSpecialMethodSensorTypeConfigs();
-			assertThat(sensorTypeConfigs, hasSize(1));
-			assertThat(sensorTypeConfigs.iterator().next().getClassName(), is(equalTo(eisc.getClassName())));
+			assertThat(Iterators.get(sensorTypeConfigs.iterator(), 0).getClassName(), is(equalTo(eisc.getClassName())));
+			assertThat(Iterators.get(sensorTypeConfigs.iterator(), 1).getClassName(), is(equalTo(closeableHttpAsyncCLient.getClassName())));
 		}
 
 		@Test
@@ -285,7 +296,7 @@ public class ConfigurationCreatorTest extends TestBase {
 			AgentConfig agentConfiguration = creator.environmentToConfiguration(environment, agentId);
 
 			Collection<MethodSensorTypeConfig> sensorTypeConfigs = agentConfiguration.getSpecialMethodSensorTypeConfigs();
-			assertThat(sensorTypeConfigs, hasSize(2));
+			assertThat(sensorTypeConfigs, hasSize(3));
 			// first element will be class loading config
 			MethodSensorTypeConfig sensorTypeConfig = sensorTypeConfigs.iterator().next();
 			assertThat(sensorTypeConfig.getId(), is(sensorId));
@@ -296,6 +307,7 @@ public class ConfigurationCreatorTest extends TestBase {
 
 			verify(registrationService).registerMethodSensorTypeIdent(agentId, cldConfig.getClassName(), cldConfig.getParameters());
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -352,7 +364,7 @@ public class ConfigurationCreatorTest extends TestBase {
 			AgentConfig agentConfiguration = creator.environmentToConfiguration(environment, agentId);
 
 			Collection<MethodSensorTypeConfig> sensorTypeConfigs = agentConfiguration.getSpecialMethodSensorTypeConfigs();
-			assertThat(sensorTypeConfigs, hasSize(2));
+			assertThat(sensorTypeConfigs, hasSize(3));
 			// first element will be mbean server interceptor config
 			MethodSensorTypeConfig sensorTypeConfig = sensorTypeConfigs.iterator().next();
 			assertThat(sensorTypeConfig.getId(), is(sensorId));
@@ -365,6 +377,7 @@ public class ConfigurationCreatorTest extends TestBase {
 			// needed because jmx sensor will be also registered
 			verify(registrationService).registerJmxSensorTypeIdent(anyLong(), anyString());
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
 
@@ -378,13 +391,12 @@ public class ConfigurationCreatorTest extends TestBase {
 			AgentConfig agentConfiguration = creator.environmentToConfiguration(environment, agentId);
 
 			Collection<MethodSensorTypeConfig> sensorTypeConfigs = agentConfiguration.getSpecialMethodSensorTypeConfigs();
-			assertThat(sensorTypeConfigs, hasSize(1));
+			assertThat(sensorTypeConfigs, hasSize(2));
 			assertThat(sensorTypeConfigs.iterator().next().getClassName(), is(equalTo(eisc.getClassName())));
 
 			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(eisc.getClassName()), eq(eisc.getParameters()));
+			verify(registrationService).registerMethodSensorTypeIdent(anyLong(), eq(closeableHttpAsyncCLient.getClassName()), eq(closeableHttpAsyncCLient.getParameters()));
 			verifyNoMoreInteractions(registrationService);
 		}
-
 	}
-
 }

--- a/inspectit.shared.all/src/main/java/rocks/inspectit/shared/all/instrumentation/config/impl/SubstitutionDescriptor.java
+++ b/inspectit.shared.all/src/main/java/rocks/inspectit/shared/all/instrumentation/config/impl/SubstitutionDescriptor.java
@@ -32,7 +32,7 @@ public class SubstitutionDescriptor {
 	 * @param returnValueSubstitution
 	 *            If return value substitution should be performed.
 	 * @param parameterValueSubstitution
-	 *            If return value substitution should be performed.
+	 *            If parameter value substitution should be performed.
 	 */
 	public SubstitutionDescriptor(boolean returnValueSubstitution, boolean parameterValueSubstitution) {
 		this.returnValueSubstitution = returnValueSubstitution;

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/Environment.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/Environment.java
@@ -24,6 +24,7 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.ConnectionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.HttpSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.InvocationSequenceSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.Log4jLoggingSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementParameterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.StatementSensorConfig;
@@ -64,7 +65,8 @@ public class Environment extends AbstractCiData {
 	@XmlElementWrapper(name = "method-sensor-configs")
 	@XmlElementRefs({ @XmlElementRef(type = ConnectionSensorConfig.class), @XmlElementRef(type = HttpSensorConfig.class), @XmlElementRef(type = InvocationSequenceSensorConfig.class),
 		@XmlElementRef(type = PreparedStatementParameterSensorConfig.class), @XmlElementRef(type = PreparedStatementSensorConfig.class), @XmlElementRef(type = StatementSensorConfig.class),
-		@XmlElementRef(type = TimerSensorConfig.class), @XmlElementRef(type = Log4jLoggingSensorConfig.class), @XmlElementRef(type = AbstractRemoteSensorConfig.class) })
+		@XmlElementRef(type = TimerSensorConfig.class), @XmlElementRef(type = Log4jLoggingSensorConfig.class), @XmlElementRef(type = AbstractRemoteSensorConfig.class),
+		@XmlElementRef(type = ApacheClientExchangeHandlerSensorConfig.class) })
 	private final List<IMethodSensorConfig> methodSensorConfigs = ConfigurationDefaultsFactory.getAvailableMethodSensorConfigs();
 
 	/**

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/factory/ConfigurationDefaultsFactory.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/factory/ConfigurationDefaultsFactory.java
@@ -17,9 +17,11 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.ExecutorClientSensorConfi
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.HttpSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.InvocationSequenceSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.Log4jLoggingSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementParameterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteAsyncApacheHttpClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJavaHttpServerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJettyHttpClientV61ClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJmsClientSensorConfig;
@@ -96,6 +98,8 @@ public final class ConfigurationDefaultsFactory {
 		methodSensorConfigs.add(new RemoteJmsListenerServerSensorConfig());
 		methodSensorConfigs.add(new RemoteManualServerSensorConfig());
 		methodSensorConfigs.add(new ExecutorClientSensorConfig());
+		methodSensorConfigs.add(new RemoteAsyncApacheHttpClientSensorConfig());
+		methodSensorConfigs.add(new ApacheClientExchangeHandlerSensorConfig());
 		return methodSensorConfigs;
 	}
 

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/factory/SpecialMethodSensorAssignmentFactory.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/factory/SpecialMethodSensorAssignmentFactory.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.xml.bind.annotation.XmlTransient;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
 import rocks.inspectit.shared.cs.ci.Environment;
 import rocks.inspectit.shared.cs.ci.assignment.impl.SpecialMethodSensorAssignment;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ClassLoadingDelegationSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.CloseableHttpAsyncClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.EUMInstrumentationSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ExecutorIntercepterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.MBeanServerInterceptorSensorConfig;
@@ -49,6 +51,11 @@ public class SpecialMethodSensorAssignmentFactory {
 	private Collection<SpecialMethodSensorAssignment> executorInterceptorAssignments;
 
 	/**
+	 * Assignments for the closeable http async client.
+	 */
+	private Collection<SpecialMethodSensorAssignment> closeableHttpAsyncClientAssignments;
+
+	/**
 	 * Private as factory.
 	 */
 	protected SpecialMethodSensorAssignmentFactory() {
@@ -77,6 +84,7 @@ public class SpecialMethodSensorAssignmentFactory {
 		}
 
 		assignments.addAll(executorInterceptorAssignments);
+		assignments.addAll(closeableHttpAsyncClientAssignments);
 
 		return assignments;
 	}
@@ -153,6 +161,14 @@ public class SpecialMethodSensorAssignmentFactory {
 		execSubmitRunnableInstr.setParameters(Arrays.asList("java.lang.Runnable"));
 
 		executorInterceptorAssignments = Arrays.asList(execSubmitRunnableInstr);
+
+		SpecialMethodSensorAssignment closeableHttpAsyncClientInstr = new SpecialMethodSensorAssignment(CloseableHttpAsyncClientSensorConfig.INSTANCE);
+		closeableHttpAsyncClientInstr.setClassName("org.apache.http.impl.nio.client.CloseableHttpAsyncClient");
+		closeableHttpAsyncClientInstr.setMethodName("execute");
+		List<String> executeParameters = Arrays.asList("org.apache.http.HttpHost", "org.apache.http.HttpRequest", "org.apache.http.protocol.HttpContext", "org.apache.http.concurrent.FutureCallback");
+		closeableHttpAsyncClientInstr.setParameters(executeParameters);
+
+		closeableHttpAsyncClientAssignments = Arrays.asList(closeableHttpAsyncClientInstr);
 	}
 
 }

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/AbstractMethodSensorConfig.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/AbstractMethodSensorConfig.java
@@ -9,6 +9,7 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.ConnectionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.ExecutorClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.HttpSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.InvocationSequenceSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementParameterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.StatementSensorConfig;
@@ -21,7 +22,7 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.TimerSensorConfig;
  *
  */
 @XmlSeeAlso({ ConnectionSensorConfig.class, HttpSensorConfig.class, InvocationSequenceSensorConfig.class, PreparedStatementParameterSensorConfig.class, PreparedStatementSensorConfig.class,
-	StatementSensorConfig.class, TimerSensorConfig.class, ExecutorClientSensorConfig.class })
+		StatementSensorConfig.class, TimerSensorConfig.class, ExecutorClientSensorConfig.class, ApacheClientExchangeHandlerSensorConfig.class })
 public abstract class AbstractMethodSensorConfig implements IMethodSensorConfig {
 
 	/**

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/AbstractRemoteSensorConfig.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/AbstractRemoteSensorConfig.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 
 import rocks.inspectit.shared.all.instrumentation.config.PriorityEnum;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteAsyncApacheHttpClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJavaHttpServerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJettyHttpClientV61ClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJmsClientSensorConfig;
@@ -21,8 +22,9 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteUrlConnectionClient
  * @author Thomas Kluge
  *
  */
-@XmlSeeAlso({ RemoteJavaHttpServerSensorConfig.class, RemoteJmsListenerServerSensorConfig.class, RemoteApacheHttpClientV40SensorConfig.class, RemoteUrlConnectionClientSensorConfig.class,
-	RemoteJettyHttpClientV61ClientSensorConfig.class, RemoteSpringRestTemplateClientSensorConfig.class, RemoteJmsClientSensorConfig.class, RemoteManualServerSensorConfig.class })
+@XmlSeeAlso({ RemoteJavaHttpServerSensorConfig.class, RemoteJmsListenerServerSensorConfig.class, RemoteApacheHttpClientV40SensorConfig.class, RemoteAsyncApacheHttpClientSensorConfig.class,
+	RemoteUrlConnectionClientSensorConfig.class, RemoteJettyHttpClientV61ClientSensorConfig.class, RemoteSpringRestTemplateClientSensorConfig.class, RemoteJmsClientSensorConfig.class,
+	RemoteManualServerSensorConfig.class })
 public abstract class AbstractRemoteSensorConfig implements IMethodSensorConfig {
 
 	/**

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/impl/ApacheClientExchangeHandlerSensorConfig.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/impl/ApacheClientExchangeHandlerSensorConfig.java
@@ -1,0 +1,61 @@
+package rocks.inspectit.shared.cs.ci.sensor.method.impl;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import rocks.inspectit.shared.all.instrumentation.config.PriorityEnum;
+import rocks.inspectit.shared.cs.ci.sensor.method.AbstractMethodSensorConfig;
+
+/**
+ * The configuration for the
+ * {@link rocks.inspectit.agent.java.sensor.method.async.http.ApacheClientExchangeHandlerSensor}
+ * class.
+ *
+ * @author Isabel Vico Peinado
+ * @author Marius Oehler
+ *
+ */
+@XmlRootElement(name = "apache-client-exchange-handler-sensor")
+public final class ApacheClientExchangeHandlerSensorConfig extends AbstractMethodSensorConfig {
+
+	/**
+	 * Sensor name.
+	 */
+	private static final String SENSOR_NAME = "Apache Client Exchange Handler Sensor";
+
+	/**
+	 * Implementing class name.
+	 */
+	public static final String CLASS_NAME = "rocks.inspectit.agent.java.sensor.method.async.http.ApacheClientExchangeHandlerSensor";
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getName() {
+		return SENSOR_NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getClassName() {
+		return CLASS_NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public PriorityEnum getPriority() {
+		return PriorityEnum.NORMAL;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isAdvanced() {
+		return true;
+	}
+}

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/impl/RemoteAsyncApacheHttpClientSensorConfig.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/impl/RemoteAsyncApacheHttpClientSensorConfig.java
@@ -1,0 +1,48 @@
+package rocks.inspectit.shared.cs.ci.sensor.method.impl;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import rocks.inspectit.shared.cs.ci.sensor.method.AbstractRemoteSensorConfig;
+
+/**
+ * Remote Async Apache HttpClient sensor config.
+ *
+ * @author Isabel Vico Peinado
+ *
+ */
+@XmlRootElement(name = "remote-async-apache-httpclient-sensor-config")
+public class RemoteAsyncApacheHttpClientSensorConfig extends AbstractRemoteSensorConfig {
+	/**
+	 * Sensor name.
+	 */
+	public static final String SENSOR_NAME = "Remote Async Apache HTTP Client Sensor";
+
+	/**
+	 * Implementing class name.
+	 */
+	public static final String CLASS_NAME = "rocks.inspectit.agent.java.sensor.method.remote.client.http.ApacheAsyncHttpClientSensor";
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getClassName() {
+		return CLASS_NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getName() {
+		return SENSOR_NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isServerSide() {
+		return false;
+	}
+}

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/special/impl/CloseableHttpAsyncClientSensorConfig.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/ci/sensor/method/special/impl/CloseableHttpAsyncClientSensorConfig.java
@@ -1,0 +1,59 @@
+package rocks.inspectit.shared.cs.ci.sensor.method.special.impl;
+
+import rocks.inspectit.shared.all.instrumentation.config.impl.SubstitutionDescriptor;
+import rocks.inspectit.shared.cs.ci.sensor.method.special.AbstractSpecialMethodSensorConfig;
+
+/**
+ * Configuration for the
+ * {@link rocks.inspectit.agent.java.sensor.method.special.CloseableHttpAsyncClientSensor} class.
+ *
+ * @author Isabel Vico Peinado
+ *
+ */
+public final class CloseableHttpAsyncClientSensorConfig extends AbstractSpecialMethodSensorConfig {
+
+	/**
+	 * Sensor name.
+	 */
+	private static final String SENSOR_NAME = "Closeable Http Async Client Sensor";
+
+	/**
+	 * Implementing class name.
+	 */
+	public static final String CLASS_NAME = "rocks.inspectit.agent.java.sensor.method.special.CloseableHttpAsyncClientSensor";
+
+	/**
+	 * Singleton instance to use.
+	 */
+	public static final CloseableHttpAsyncClientSensorConfig INSTANCE = new CloseableHttpAsyncClientSensorConfig();
+
+	/**
+	 * Private constructor, use {@link #INSTANCE}.
+	 */
+	private CloseableHttpAsyncClientSensorConfig() {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getName() {
+		return SENSOR_NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getClassName() {
+		return CLASS_NAME;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public SubstitutionDescriptor getSubstitutionDescriptor() {
+		return new SubstitutionDescriptor(false, true);
+	}
+}

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/jaxb/ISchemaVersionAware.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/jaxb/ISchemaVersionAware.java
@@ -25,6 +25,6 @@ public interface ISchemaVersionAware {
 	interface ConfigurationInterface {
 
 		/** Current version. */
-		int SCHEMA_VERSION = 7;
+		int SCHEMA_VERSION = 8;
 	}
 }

--- a/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/storage/serializer/SerializationManagerPostProcessor.java
+++ b/inspectit.shared.cs/src/main/java/rocks/inspectit/shared/cs/storage/serializer/SerializationManagerPostProcessor.java
@@ -63,9 +63,11 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.ExecutorClientSensorConfi
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.HttpSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.InvocationSequenceSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.Log4jLoggingSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementParameterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteAsyncApacheHttpClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJavaHttpServerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJettyHttpClientV61ClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJmsClientSensorConfig;
@@ -454,6 +456,10 @@ public class SerializationManagerPostProcessor implements BeanPostProcessor {
 
 		// INSPECTIT-2192
 		kryo.register(AgentNameValueSource.class, new FieldSerializer<AgentNameValueSource>(kryo, AgentNameValueSource.class), nextRegistrationId++);
+
+		// INSPECTIT-2458
+		kryo.register(RemoteAsyncApacheHttpClientSensorConfig.class, new FieldSerializer<>(kryo, RemoteAsyncApacheHttpClientSensorConfig.class), nextRegistrationId++);
+		kryo.register(ApacheClientExchangeHandlerSensorConfig.class, new FieldSerializer<>(kryo, ApacheClientExchangeHandlerSensorConfig.class), nextRegistrationId++);
 	}
 
 }

--- a/inspectit.ui.rcp/src/main/java/rocks/inspectit/ui/rcp/formatter/ImageFormatter.java
+++ b/inspectit.ui.rcp/src/main/java/rocks/inspectit/ui/rcp/formatter/ImageFormatter.java
@@ -47,6 +47,7 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.ConnectionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.HttpSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.InvocationSequenceSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.Log4jLoggingSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementParameterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.StatementSensorConfig;
@@ -446,6 +447,8 @@ public final class ImageFormatter {
 		} else if (ObjectUtils.equals(sensorClass, JmxSensorConfig.class)) {
 			return InspectIT.getDefault().getImage(InspectITImages.IMG_BEAN);
 		} else if (AbstractRemoteSensorConfig.class.isAssignableFrom(sensorClass)) {
+			return InspectIT.getDefault().getImage(InspectITImages.IMG_REMOTE);
+		} else if (ObjectUtils.equals(sensorClass, ApacheClientExchangeHandlerSensorConfig.class)) {
 			return InspectIT.getDefault().getImage(InspectITImages.IMG_REMOTE);
 		}
 		return null;

--- a/inspectit.ui.rcp/src/main/java/rocks/inspectit/ui/rcp/model/SensorTypeEnum.java
+++ b/inspectit.ui.rcp/src/main/java/rocks/inspectit/ui/rcp/model/SensorTypeEnum.java
@@ -11,6 +11,7 @@ import rocks.inspectit.shared.all.cmr.model.MethodIdentToSensorType;
 import rocks.inspectit.shared.all.cmr.model.SensorTypeIdent;
 import rocks.inspectit.shared.cs.ci.sensor.exception.impl.ExceptionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.AbstractRemoteSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.ApacheClientExchangeHandlerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.ConnectionSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.ExecutorClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.HttpSensorConfig;
@@ -19,6 +20,7 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.Log4jLoggingSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementParameterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.PreparedStatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteApacheHttpClientV40SensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteAsyncApacheHttpClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJavaHttpServerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJettyHttpClientV61ClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteJmsClientSensorConfig;
@@ -29,6 +31,7 @@ import rocks.inspectit.shared.cs.ci.sensor.method.impl.RemoteUrlConnectionClient
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.StatementSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.impl.TimerSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ClassLoadingDelegationSensorConfig;
+import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.CloseableHttpAsyncClientSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.EUMInstrumentationSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.ExecutorIntercepterSensorConfig;
 import rocks.inspectit.shared.cs.ci.sensor.method.special.impl.MBeanServerInterceptorSensorConfig;
@@ -111,6 +114,8 @@ public enum SensorTypeEnum {
 	ALERT_INVOCATION(InvocationSequenceSensorConfig.CLASS_NAME + "#alert", InspectITImages.IMG_ALARM_INVOCATION),
 	/** The Remote Apache sensor. */
 	REMOTE_APACHE_HTTP_CLIENT_V40(RemoteApacheHttpClientV40SensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false),
+	/** The Remote Async Apache sensor. */
+	REMOTE_ASYNC_APACHE_HTTP(RemoteAsyncApacheHttpClientSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false),
 	/** The Remote UrlConnection sensor. */
 	REMOTE_HTTP_URL_CONNECTION(RemoteUrlConnectionClientSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false),
 	/** The Remote UrlConnection sensor. */
@@ -134,7 +139,11 @@ public enum SensorTypeEnum {
 	/** Special sensor for substituting {@link java.lang.Runnable}s for thread correlation. */
 	EXECUTOR_INTERCEPTOR(ExecutorIntercepterSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false),
 	/** Executor client sensor for correlating threads via executors. */
-	EXECUTOR_CLIENT(ExecutorClientSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false);
+	EXECUTOR_CLIENT(ExecutorClientSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false),
+	/** Apache client exchange handler sensor. */
+	APACHE_CLIENT_EXCHANGE_HANDLER(ApacheClientExchangeHandlerSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false),
+	/** HTTP async-client sensor for asynchronous tracing via Apache library. */
+	CLOSEABLE_HTTP_ASYNC_CLIENT(CloseableHttpAsyncClientSensorConfig.CLASS_NAME, InspectITImages.IMG_REMOTE, false);
 
 	/**
 	 * The LOOKUP map which is used to get an element of the enumeration when passing the full


### PR DESCRIPTION
Created ApacheAsyncHttpClientSensor and its tests, created RemoteAsyncApacheHttpClientSensorConfig and updated all files where needed.
Created special sensor in order to allow to create the proxies. Created proxy for Future callback and for HttpRequestInterceptor to start the span an stop it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/347)
<!-- Reviewable:end -->
