### PR TITLE
INSPECTIT-2568: fixed bug in the TcpConnection that caused communicat…

### DIFF
--- a/inspectit.shared.all/src/main/java/rocks/inspectit/shared/all/kryonet/TcpConnection.java
+++ b/inspectit.shared.all/src/main/java/rocks/inspectit/shared/all/kryonet/TcpConnection.java
@@ -244,30 +244,27 @@ class TcpConnection {
 			}
 
 			// calculate how much we have already written
-			try {
-				long written = 0;
-				List<ByteBuffer> buffers = outputStream.getAllByteBuffers();
-				for (ByteBuffer buffer : buffers) {
-					written += buffer.position();
-				}
-
-				// then try to write until the end
-				while (written < outputStream.getTotalWriteSize()) {
-					long writeSize = socketChannel.write(buffers.toArray(new ByteBuffer[buffers.size()]));
-					if (0 == writeSize) {
-						// if we can not write any more we go out
-						break outerloop;
-					}
-					written += writeSize;
-				}
-			} finally {
-				// here we have done with this output stream
-				// remove it from the write queue, prepare for new usage and return to the idle
-				// queue
-				writeQueue.remove(outputStream);
-				outputStream.prepare();
-				idleQueue.offer(outputStream);
+			long written = 0;
+			List<ByteBuffer> buffers = outputStream.getAllByteBuffers();
+			for (ByteBuffer buffer : buffers) {
+				written += buffer.position();
 			}
+
+			// then try to write until the end
+			while (written < outputStream.getTotalWriteSize()) {
+				long writeSize = socketChannel.write(buffers.toArray(new ByteBuffer[buffers.size()]));
+				if (0 == writeSize) {
+					// if we can not write any more we go out
+					break outerloop;
+				}
+				written += writeSize;
+			}
+			// here we have done with this output stream
+			// remove it from the write queue, prepare for new usage and return to the idle
+			// queue
+			writeQueue.remove(outputStream);
+			outputStream.prepare();
+			idleQueue.offer(outputStream);
 		}
 
 		return writeQueue.isEmpty();

--- a/inspectit.shared.all/src/main/java/rocks/inspectit/shared/all/storage/nio/ByteBufferProvider.java
+++ b/inspectit.shared.all/src/main/java/rocks/inspectit/shared/all/storage/nio/ByteBufferProvider.java
@@ -252,12 +252,12 @@ public class ByteBufferProvider extends GenericObjectPool<ByteBuffer> implements
 		// assume that the maxDirect memory is 64MB
 		long maxDirectMemory = 64 * 1024 * 1024;
 		try {
-			if (UnderlyingSystemInfo.JVM_PROVIDER.equals(JvmProvider.SUN) || UnderlyingSystemInfo.JVM_PROVIDER.equals(JvmProvider.ORACLE)) {
-				Class<?> vmClazz = Class.forName("sun.misc.VM");
-				Method directMemoryMethod = vmClazz.getMethod("maxDirectMemory");
-				directMemoryMethod.setAccessible(true);
-				maxDirectMemory = (Long) directMemoryMethod.invoke(null);
-			}
+			Class<?> vmClazz = Class.forName("sun.misc.VM");
+			Method directMemoryMethod = vmClazz.getMethod("maxDirectMemory");
+			directMemoryMethod.setAccessible(true);
+			maxDirectMemory = (Long) directMemoryMethod.invoke(null);
+
+			log.debug("Direct memory available for the JVM {}", maxDirectMemory);
 		} catch (Exception e) {
 			if (log.isDebugEnabled()) {
 				log.debug("Exception occurred trying to use the class sun.misc.VM via reflection", e);
@@ -275,6 +275,9 @@ public class ByteBufferProvider extends GenericObjectPool<ByteBuffer> implements
 		int maxActive = (int) (poolMaxCapacity / bufferSize);
 		super.setMaxIdle(maxIdle);
 		super.setMaxActive(maxActive);
+
+		log.info("|-Updated byte buffer pool capacity, maxIdle={} and maxActive={}", maxIdle, maxActive);
+		log.info("|-Default byte buffer size set to {}", bufferSize);
 	}
 
 	/**

--- a/inspectit.shared.all/src/test/java/rocks/inspectit/shared/all/storage/nio/ByteBufferProviderTest.java
+++ b/inspectit.shared.all/src/test/java/rocks/inspectit/shared/all/storage/nio/ByteBufferProviderTest.java
@@ -4,12 +4,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -36,6 +38,7 @@ public class ByteBufferProviderTest {
 	@BeforeMethod
 	public void init() {
 		byteBufferProvider = new ByteBufferProvider(new ByteBufferFactory(1), 1);
+		byteBufferProvider.log = mock(Logger.class);
 		byteBufferProvider.setBufferPoolMaxDirectMemoryOccupancy(0.6f);
 		byteBufferProvider.setBufferPoolMinDirectMemoryOccupancy(0.3f);
 	}


### PR DESCRIPTION
The bug was related to the fact that `break outerloop;` was in the try/finally catch. This could cause the non-drained stream to be released when we wrote zero bytes to the socket channel. Effectively when this happens, instead of resuming later on, we dismiss the bytes, meaning the reading side receive invalid order of bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/inspectit/inspectit/401)
<!-- Reviewable:end -->
